### PR TITLE
Fix a few errors

### DIFF
--- a/src/Console/Command/Task/StageTask.php
+++ b/src/Console/Command/Task/StageTask.php
@@ -15,6 +15,7 @@
 namespace Cake\Upgrade\Console\Command\Task;
 
 use Cake\Console\Shell;
+use Cake\Error\InternalErrorException;
 use Cake\Utility\Debugger;
 use Cake\Utility\File;
 use Cake\Utility\Folder;
@@ -330,6 +331,10 @@ class StageTask extends Shell {
  * @return string
  */
 	protected function _getPath() {
+		if (empty($this->args[0]) || !file_exists($this->args[0])) {
+			throw new InternalErrorException('Path not specified or invalid.');
+		}
+
 		if (count($this->args) === 1) {
 			return realpath($this->args[0]);
 		}

--- a/src/Console/Command/UpgradeShell.php
+++ b/src/Console/Command/UpgradeShell.php
@@ -45,7 +45,7 @@ class UpgradeShell extends Shell {
 	);
 
 	public function main() {
-		if ($this->params['dry-run']) {
+		if (!empty($this->params['dry-run'])) {
 			$this->out('<warning>Dry-run mode enabled!</warning>', 1, Shell::QUIET);
 		}
 
@@ -81,7 +81,7 @@ class UpgradeShell extends Shell {
 			if ($name === 'all') {
 				continue;
 			}
-			$className = ucfirst(Inflector::Camelize($name));
+			$className = ucfirst(Inflector::camelize($name));
 			$all[$name] = $className;
 		}
 		return $all;


### PR DESCRIPTION
Fix a few minor things.

Also: When using `cake upgrade` without any argument it would currently self-update itself and all vendor files, which is a bad thing.
The InternalErrorException prevents this for now.

I still get stuff like

> Notice Error: Undefined index: namespace

But that should be fixed once param() is available.
