### PR TITLE
Add Helper -> UrlHelper mapping.

### DIFF
--- a/src/Shell/Task/UpdateMethodNamesTask.php
+++ b/src/Shell/Task/UpdateMethodNamesTask.php
@@ -37,9 +37,29 @@ class UpdateMethodNamesTask extends BaseTask {
 	protected function _process($path) {
 		$helperPatterns = [
 			[
-				'Replace $this->Paginator->url() with $this->Paginator->generateUrl',
+				'Replace $this->Paginator->url() with $this->Paginator->generateUrl()',
 				'#\$this->Paginator->url\(#',
 				'$this->Paginator->generateUrl(',
+			],
+			[
+				'Replace $this->Html->url() with $this->Url->build()',
+				'#\$this->Html->url\(#',
+				'$this->Url->build(',
+			],
+			[
+				'Replace $this->Html->assetTimestamp() with $this->Url->assetTimestamp()',
+				'#\$this->Html->assetTimestamp\(#',
+				'$this->Url->assetTimestamp(',
+			],
+			[
+				'Replace $this->Html->assetUrl() with $this->Url->assetUrl()',
+				'#\$this->Html->assetUrl\(#',
+				'$this->Url->assetUrl(',
+			],
+			[
+				'Replace $this->Html->webroot() with $this->Url->webroot()',
+				'#\$this->Html->webroot\(#',
+				'$this->Url->webroot(',
 			],
 		];
 


### PR DESCRIPTION
Resolves https://github.com/cakephp/upgrade/issues/25

Helper methods have been moved to Url helper.
In general it was most common to use the Html helper to get access those methods, thus the change for this specific helper.
Other helper calls or internal calls via `$this->webroot()` or `$this->url()` will not be possible to auto-correct due to a very high chance of false-positives with similar method names.
