### PR TITLE
Correctly relocate files.

### DIFF
--- a/src/Shell/Task/LocationsTask.php
+++ b/src/Shell/Task/LocationsTask.php
@@ -38,11 +38,11 @@ class LocationsTask extends BaseTask {
 			if (!$this->_isInRoot($to)) {
 				$to = 'src' . DS . $to;
 			}
-			if ($from === 'Lib' && !empty($this->params['lib'])) {
+			if ($from === 'Lib') {
 				$pieces = explode(DS . $from . DS, $new);
 				$ending = array_pop($pieces);
 				if (strpos($ending, DS) === false) {
-					$to .= DS . str_replace('/', DS, $this->params['lib']);
+					$to .= DS . 'Lib';
 				}
 			}
 
@@ -161,10 +161,6 @@ class LocationsTask extends BaseTask {
 	public function getOptionParser() {
 		return parent::getOptionParser()
 			->addOptions([
-				'lib' => [
-					'default' => '',
-					'help' => 'Define where Lib class files should go that have not a namespaced subfolder, e.g. `Lib` for `src/Lib`. By default they go into `src`.'
-				],
 				'root' => [
 					'default' => '',
 					'help' => 'Set an application\'s root path. Not defining it makes the current path the root one.'


### PR DESCRIPTION
Start reworking the locations task.
Currently it would re-locale wrongly or into subsubsub "src" folders when run more than once, which is also a bad thing.
The false positives is causing quite the mess, especially since it does not properly take into account two different scenarios.
- Cake2 app with APP=ROOT
- Cake2 app with APP=src

This change can now handle both types by using the passed folder argument as root if no specific `--root` is passed.

This is not quite finished and I would also want to add tests, but I also want to get some early feedback.

As sideeffect also now corrected:
- bin
- TestCase under tests (not Test)
