### PR TITLE
Dont src/src and dont skip if folder names occure outside of the scope

### DIFF
--- a/src/Shell/Task/LocationsTask.php
+++ b/src/Shell/Task/LocationsTask.php
@@ -65,15 +65,19 @@ class LocationsTask extends BaseTask {
  * @return bool
  */
 	protected function _shouldProcess($path) {
-		if (strpos($path, DS . 'Plugin' . DS) || strpos($path, DS . 'plugins' . DS)) {
+		$root = !empty($this->params['root']) ? $this->params['root'] : $this->args[0];
+		$root = rtrim($root, DS);
+		$relativeFromRoot = str_replace($root, '', $path);
+
+		if (strpos($relativeFromRoot, DS . 'Plugin' . DS) || strpos($relativeFromRoot, DS . 'plugins' . DS)) {
 			return false;
 		}
-		if (strpos($path, DS . 'Vendor' . DS) || strpos($path, DS . 'vendors' . DS)) {
+		if (strpos($relativeFromRoot, DS . 'Vendor' . DS) || strpos($relativeFromRoot, DS . 'vendors' . DS)) {
 			return false;
 		}
 
 		foreach (array_keys($this->_moves()) as $substr) {
-			if (strpos($path, DS . $substr . DS) !== false) {
+			if (strpos($relativeFromRoot, DS . $substr . DS) !== false) {
 				return true;
 			}
 		}
@@ -147,6 +151,7 @@ class LocationsTask extends BaseTask {
 			'config',
 			'bin',
 			'tests',
+			'src'
 		);
 		$pieces = explode(DS, $folder);
 		$firstFolder = !empty($pieces[0]) ? $pieces[0] : $folder;

--- a/src/Shell/Task/NamespacesTask.php
+++ b/src/Shell/Task/NamespacesTask.php
@@ -45,7 +45,7 @@ class NamespacesTask extends BaseTask {
 			[
 				'Namespace to ' . $namespace,
 				'#^(<\?(?:php)?\s+(?:\/\*.*?\*\/\s{0,1})?)#s',
-				"\\1namespace " . $namespace . ";\n",
+				"\\1namespace " . $namespace . ";\n\n",
 			]
 		];
 		$contents = $this->_updateContents($contents, $patterns);
@@ -81,10 +81,14 @@ class NamespacesTask extends BaseTask {
  * @return bool
  */
 	protected function _shouldProcess($path) {
-		if (strpos($path, DS . 'Plugin' . DS) || strpos($path, DS . 'plugins' . DS)) {
+		$root = !empty($this->params['root']) ? $this->params['root'] : $this->args[0];
+		$root = rtrim($root, DS);
+		$relativeFromRoot = str_replace($root, '', $path);
+
+		if (strpos($relativeFromRoot, DS . 'Plugin' . DS) || strpos($relativeFromRoot, DS . 'plugins' . DS)) {
 			return false;
 		}
-		if (strpos($path, DS . 'Vendor' . DS) || strpos($path, DS . 'vendors' . DS)) {
+		if (strpos($relativeFromRoot, DS . 'Vendor' . DS) || strpos($relativeFromRoot, DS . 'vendors' . DS)) {
 			return false;
 		}
 


### PR DESCRIPTION
This fixes:

- src/src happening

- skipping too much, e.g. when the folder is `some/Vendor/path/to/app/` (here Vendor is just part of the path to the actual app, and as such all files would be skipped. $relativeFromRoot should actually be used in every _shouldProcess IMO to avoid those false positives. Maybe we have to provide a Stage task method to retrieve this relative path?

Imagine `some/Lib/Controller/foo/bar/myapp` path. With myapp being the actual app. It would probably place quite a few files wrongly (or run them) because the words are somewhere in the path string. Whereas it should only check for everything beyond `/myapp` here.