### PR TITLE
Removed old array syntax for consistency

### DIFF
--- a/src/Shell/UpgradeShell.php
+++ b/src/Shell/UpgradeShell.php
@@ -73,7 +73,7 @@ class UpgradeShell extends Shell
         foreach ($actions as $action) {
             $this->out(sprintf('<info>*** Upgrade step %s ***</info>', $action));
             if (!empty($this->params['interactive'])) {
-                $continue = $this->in('Continue with `' . $action . '`?', array('y', 'n', 'q'), 'y');
+                $continue = $this->in('Continue with `' . $action . '`?', ['y', 'n', 'q'], 'y');
                 if ($continue === 'q') {
                     return $this->error('Aborted. Changes are not commited.');
                 }
@@ -190,11 +190,11 @@ class UpgradeShell extends Shell
             }
             $allParser->merge($subcommand->parser());
         }
-        $allParser->addOption('interactive', array(
+        $allParser->addOption('interactive', [
                 'short' => 'i',
                 'help' => 'Run all commands in an interactive mode. Allows you to selectively apply specific steps.',
                 'boolean' => true
-            ));
+            ]);
 
         return $parser->addSubcommand('all', [
             'help' => 'Run all tasks expect for skeleton. That task should only be run manually, and only for apps (not plugins).',


### PR DESCRIPTION
Some usage of the old array syntax mixed in with the new `[]` notation. Removed for consistency and clarity. 

Regards