### PR TITLE
plugin installer seems to be required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
 	"require": {
 		"cakephp/cakephp": "~3.0",
 		"cakephp/app": "~3.0",
-		"phpunit/phpunit": "*"
+		"phpunit/phpunit": "*",
+		"cakephp/plugin-installer": "^0.0.12"
 	},
 	"autoload": {
 		"psr-4": {
@@ -20,5 +21,7 @@
 	"support": {
 		"source": "https://github.com/cakephp/upgrade"
 	},
-	"post-autoload-dump": "Cake\\Composer\\Installer\\PluginInstaller::postAutoloadDump"
+    "scripts": {
+        "post-autoload-dump": "Cake\\Composer\\Installer\\PluginInstaller::postAutoloadDump"
+    }
 }


### PR DESCRIPTION
Here's the message I received when installing the upgrade tool : https://www.evernote.com/shard/s13/sh/fdd799c7-c205-4222-9690-59134d5edc5c/61940fb5065522914301a40ddd4010bb.   Making these changes removes the message.