### PR TITLE
should also process .ctp files for helperPatterns to be replaced

### DIFF
--- a/src/Shell/Task/MethodNamesTask.php
+++ b/src/Shell/Task/MethodNamesTask.php
@@ -117,4 +117,18 @@ class MethodNamesTask extends BaseTask
 
         return $this->Stage->change($path, $original, $contents);
     }
+
+    /**
+     * _shouldProcess
+     *
+     * Bail for invalid files (php/ctp files only)
+     *
+     * @param string $path
+     * @return bool
+     */
+    protected function _shouldProcess($path)
+    {
+        $ending = substr($path, -4);
+        return $ending === '.php' || $ending === '.ctp';
+    }
 }


### PR DESCRIPTION
$helperPatterns are never replaced in .ctp files, since shouldProcess() by default only checks for .php files

Maybe a bit late to the game, but better late then never.