### PR TITLE
Add PHPUnit version constraint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
+  - 7.3
 
 sudo: false
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	"require": {
 		"cakephp/cakephp": "~3.0",
 		"cakephp/app": "~3.0",
-		"phpunit/phpunit": "*",
+		"phpunit/phpunit": "^5.7.14|^6.0",
 		"cakephp/plugin-installer": "~1.0"
 	},
 	"autoload": {


### PR DESCRIPTION
CakePHP 3.x is not yet compatible with PHPUnit 7+.

Fixes https://github.com/cakephp/cakephp/issues/13037