### PR TITLE
Disabled and documented phpcs rules until dependencies are fixed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "cakephp/cakephp": "^4.0",
         "cakephp/cakephp-codesniffer": "^4.0",
         "mikey179/vfsstream": "^1.6",
-        "phpunit/phpunit": "^8.3.3|^8.4"
+        "phpunit/phpunit": "^8.4"
     },
     "autoload": {
         "psr-4": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -4,12 +4,16 @@
 
     <rule ref="CakePHP" />
 
-    <!-- Documented Broken Rules -->
-    <!-- Conflicts with PSR12.Files.FileHeader.SpacingAfterBlock -->
-    <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectWhitespaceBetweenOpenTagAndDeclare">
+    <!--
+        Disable manually until rector is upgrade to nikic/php-parser 5.0
+        This is downgrading to cakephp-codesniffer 4.0.0-beta3 intead of 4.0
+    -->
+    <rule ref="PSR12.Files.FileHeader.SpacingAfterBlock">
         <severity>0</severity>
     </rule>
-    <!-- Conflicts with PSR12.Files.FileHeader.SpacingAfterBlock -->
+    <rule ref="PSR12.Files.FileHeader.IncorrectOrder">
+        <severity>0</severity>
+    </rule>
     <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectWhitespaceAfterDeclare">
         <severity>0</severity>
     </rule>

--- a/src/Application.php
+++ b/src/Application.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
@@ -13,9 +14,6 @@
  * @since     3.3.0
  * @license   https://opensource.org/licenses/mit-license.php MIT License
  */
-
-declare(strict_types=1);
-
 namespace Cake\Upgrade;
 
 use Cake\Console\CommandCollection;

--- a/src/Command/FileRenameCommand.php
+++ b/src/Command/FileRenameCommand.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
@@ -13,9 +14,6 @@
  * @since         4.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-
-declare(strict_types=1);
-
 namespace Cake\Upgrade\Command;
 
 use Cake\Console\Arguments;

--- a/src/Command/RectorCommand.php
+++ b/src/Command/RectorCommand.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
@@ -13,9 +14,6 @@
  * @since         4.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-
-declare(strict_types=1);
-
 namespace Cake\Upgrade\Command;
 
 use Cake\Console\Arguments;

--- a/src/Command/UpgradeCommand.php
+++ b/src/Command/UpgradeCommand.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
@@ -13,9 +14,6 @@
  * @since         4.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-
-declare(strict_types=1);
-
 namespace Cake\Upgrade\Command;
 
 use Cake\Console\Arguments;

--- a/tests/OldApp/Command/HelloCommand.php
+++ b/tests/OldApp/Command/HelloCommand.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace OldApp\Command;

--- a/tests/TestCase/Command/FileRenameCommandTest.php
+++ b/tests/TestCase/Command/FileRenameCommandTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
@@ -13,9 +14,6 @@
  * @since         4.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-
-declare(strict_types=1);
-
 namespace Cake\Test\TestCase\Command;
 
 use Cake\Core\Configure;

--- a/tests/TestCase/Command/RectorCommandTest.php
+++ b/tests/TestCase/Command/RectorCommandTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
@@ -13,9 +14,6 @@
  * @since         4.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-
-declare(strict_types=1);
-
 namespace Cake\Test\TestCase\Command;
 
 use Cake\TestSuite\ConsoleIntegrationTestTrait;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * Test runner bootstrap.
@@ -6,8 +7,6 @@
  * Add additional configuration/setup your application needs when running
  * unit tests in this file.
  */
-
-declare(strict_types=1);
 
 error_reporting(-1);
 date_default_timezone_set('UTC');


### PR DESCRIPTION
The files were botched up in an earlier fix.

rector 0.6.3 is causing cakephp-codesniffer to downgrade to 4.0.0-beta3.