### PR TITLE
Remove require-dev and add Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,12 @@ matrix:
 before_install:
   - phpenv config-rm xdebug.ini
 
-before_script:
-  - if [[ $DEFAULT == 1 || $PHPCS == 1 ]]; then composer install; fi
+install:
+  - make install-dev
 
 script:
-  - if [[ $DEFAULT == 1 ]]; then vendor/bin/phpunit; fi
-  - if [[ $PHPCS == 1 ]]; then composer cs-check; fi
+  - if [[ $DEFAULT == 1 ]]; then make test; fi
+  - if [[ $PHPCS == 1 ]]; then make check-cs; fi
 
 cache:
   directories:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: install-dev test check-cs
+
+DEV_DEPENDENCIES = cakephp/cakephp:^4.0 \
+  cakephp/cakephp-codesniffer:^4.0 \
+  mikey179/vfsstream:^1.6 \
+  phpunit/phpunit:^8.4
+
+install-dev:
+	composer require --dev $(DEV_DEPENDENCIES)
+
+test: install-dev
+	vendor/bin/phpunit
+
+check-cs: install-dev
+	composer cs-check

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ install-dev:
 	composer require --dev $(DEV_DEPENDENCIES)
 
 test: install-dev
-	vendor/bin/phpunit
+	composer test
 
 check-cs: install-dev
 	composer cs-check

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ cd /path/to/upgrade
 # Run all upgrade tasks at once.
 bin/cake upgrade /home/mark/Sites/my-app
 
+# OR run upgrade tasks individually.
 # Rename locale files
 bin/cake upgrade file_rename locales /home/mark/Sites/my-app
 
@@ -41,7 +42,17 @@ bin/cake upgrade file_rename locales /home/mark/Sites/my-app
 bin/cake upgrade file_rename templates /home/mark/Sites/my-app
 
 # Run rector rules.
-bin/cake upgrade rector /home/mark/Sites/my-app
+bin/cake upgrade rector /home/mark/Sites/my-app/src
+bin/cake upgrade rector /home/mark/Sites/my-app/tests
+bin/cake upgrade rector /home/mark/Sites/my-app/config
 ```
 
+## Development
 
+To ease installation & usage, this package does not
+use `require-dev` in `composer.json` as the installed PHPUnit and
+CakePHP packages cause conflicts with the rector tasks.
+
+To install dev-dependencies use `make install-dev`. Then you will be able to
+run `vendor/bin/phpunit`. You can also use `make test` to install dependencies
+and run tests.

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,13 @@
     "scripts": {
         "cs-check": "phpcs --colors --parallel=16 -p -s src/ tests/",
         "cs-fix": "phpcbf --colors --parallel=16 -p src/ tests/",
+        "test": "phpunit",
         "post-autoload-dump": "Cake\\Composer\\Installer\\PluginInstaller::postAutoloadDump"
+    },
+    "require-dev": {
+        "cakephp/cakephp": "^4.0",
+        "cakephp/cakephp-codesniffer": "^4.0",
+        "mikey179/vfsstream": "^1.6",
+        "phpunit/phpunit": "^8.4"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,6 @@
         "cakephp/console": "^4.0",
         "rector/rector": "~0.6"
     },
-    "require-dev": {
-        "cakephp/cakephp": "^4.0",
-        "cakephp/cakephp-codesniffer": "^4.0",
-        "mikey179/vfsstream": "^1.6",
-        "phpunit/phpunit": "^8.4"
-    },
     "autoload": {
         "psr-4": {
             "Cake\\Upgrade\\": "src"

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -22,13 +22,7 @@ require __DIR__ . '/paths.php';
  * Bootstrap CakePHP.
  *
  * Does the various bits of setup that CakePHP needs to do.
- * This includes:
- *
- * - Registering the CakePHP autoloader.
- * - Setting the default application paths.
  */
-require CORE_PATH . 'config' . DS . 'bootstrap.php';
-
 use Cake\Core\Configure;
 use Cake\Core\Configure\Engine\PhpConfig;
 use Cake\Error\ConsoleErrorHandler;

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -25,7 +25,6 @@ require __DIR__ . '/paths.php';
  */
 use Cake\Core\Configure;
 use Cake\Core\Configure\Engine\PhpConfig;
-use Cake\Error\ConsoleErrorHandler;
 use Cake\Log\Log;
 
 /**
@@ -66,10 +65,5 @@ mb_internal_encoding(Configure::read('App.encoding'));
  * formatted and sets the default language to use for translations.
  */
 ini_set('intl.default_locale', Configure::read('App.defaultLocale'));
-
-/*
- * Register application error and exception handlers.
- */
-(new ConsoleErrorHandler(Configure::read('Error')))->register();
 
 Log::setConfig(Configure::consume('Log'));

--- a/src/Command/FileRenameCommand.php
+++ b/src/Command/FileRenameCommand.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Upgrade\Command;
 
 use Cake\Console\Arguments;
-use Cake\Console\Command;
+use Cake\Console\BaseCommand;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Core\Configure;
@@ -30,7 +30,7 @@ use RegexIterator;
 /**
  * Rename and move files
  */
-class FileRenameCommand extends Command
+class FileRenameCommand extends BaseCommand
 {
     /**
      * Is git used

--- a/src/Command/RectorCommand.php
+++ b/src/Command/RectorCommand.php
@@ -17,14 +17,14 @@ declare(strict_types=1);
 namespace Cake\Upgrade\Command;
 
 use Cake\Console\Arguments;
-use Cake\Console\Command;
+use Cake\Console\BaseCommand;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 
 /**
  * Runs rector rulesets against the provided path.
  */
-class RectorCommand extends Command
+class RectorCommand extends BaseCommand
 {
     /**
      * Execute.

--- a/src/Command/UpgradeCommand.php
+++ b/src/Command/UpgradeCommand.php
@@ -17,14 +17,14 @@ declare(strict_types=1);
 namespace Cake\Upgrade\Command;
 
 use Cake\Console\Arguments;
-use Cake\Console\Command;
+use Cake\Console\BaseCommand;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 
 /**
  * Entry point into the upgrade process
  */
-class UpgradeCommand extends Command
+class UpgradeCommand extends BaseCommand
 {
     /**
      * Execute.


### PR DESCRIPTION
Having the full CakePHP framework and PHPUnit installed is causing conflicts for users. Try removing those so that fewer packages are installed. I've also updated the commands to only depend on features provided by the console package.

Refs cakephp/cakephp#14036
Refs cakephp/cakephp#14070