### PR TITLE
Improve PHPUnit fixtures

### DIFF
--- a/tests/TestCase/Command/FileRenameCommandTest.php
+++ b/tests/TestCase/Command/FileRenameCommandTest.php
@@ -135,7 +135,7 @@ class FileRenameCommandTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -156,7 +156,7 @@ class FileRenameCommandTest extends TestCase
      *
      * @return void
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Configure::write('App.paths.plugins', $this->pluginPaths);
         Configure::write('App.paths.locales', $this->localePaths);

--- a/tests/TestCase/Command/RectorCommandTest.php
+++ b/tests/TestCase/Command/RectorCommandTest.php
@@ -36,7 +36,7 @@ class RectorCommandTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
# Changed log

- According to the [PHPUnit fixtures reference](https://phpunit.readthedocs.io/en/8.5/fixtures.html#more-setup-than-teardown), it should be `protected function setUp` and `protected function tearDown` methods.