### PR TITLE
Update rector to v0.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 DEV_DEPENDENCIES = cakephp/cakephp:^4.0 \
   cakephp/cakephp-codesniffer:^4.0 \
   mikey179/vfsstream:^1.6 \
-  phpunit/phpunit:^8.4
+  phpunit/phpunit:^9.3
 
 install-dev:
 	composer require --dev $(DEV_DEPENDENCIES)

--- a/config/rector/cakephp40.php
+++ b/config/rector/cakephp40.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Set\ValueObject\SetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    // get parameters
+    $parameters = $containerConfigurator->parameters();
+
+    // Define what rule sets will be applied
+    $parameters->set(Option::SETS, [
+	    SetList::CAKEPHP_40,
+    ]);
+};

--- a/config/rector/cakephp41.php
+++ b/config/rector/cakephp41.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Set\ValueObject\SetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    // get parameters
+    $parameters = $containerConfigurator->parameters();
+
+    // Define what rule sets will be applied
+    $parameters->set(Option::SETS, [
+	    SetList::CAKEPHP_41,
+    ]);
+};

--- a/config/rector/phpunit80.php
+++ b/config/rector/phpunit80.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Set\ValueObject\SetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    // get parameters
+    $parameters = $containerConfigurator->parameters();
+
+    // Define what rule sets will be applied
+    $parameters->set(Option::SETS, [
+	    SetList::PHPUNIT_80,
+    ]);
+};

--- a/src/Command/RectorCommand.php
+++ b/src/Command/RectorCommand.php
@@ -78,16 +78,16 @@ class RectorCommand extends BaseCommand
      */
     protected function runRector(ConsoleIo $io, Arguments $args, string $autoload): bool
     {
-        $rules = (string)$args->getOption('rules');
+        $config = ROOT . '/config/rector/' . basename((string)$args->getOption('rules')) . '.php';
         $path = realpath((string)$args->getArgument('path'));
 
         $cmdPath = ROOT . '/vendor/bin/rector process';
         $command = sprintf(
-            '%s %s --autoload-file=%s --set=%s --working-dir=%s %s',
+            '%s %s --autoload-file=%s --config=%s --working-dir=%s %s',
             $cmdPath,
             $args->getOption('dry-run') ? '--dry-run' : '',
             escapeshellarg($autoload),
-            escapeshellarg($rules),
+            escapeshellarg($config),
             escapeshellarg($path),
             escapeshellarg($path)
         );


### PR DESCRIPTION
CLI `--set` has been removed in rector v0.9 causing the `upgrade rector` command to fail. Config files are suggested to be used instead https://github.com/rectorphp/rector/blob/master/UPGRADE_09.md#from-cli---set--level-to-config

In this PR, three new config files are being introduced for PHPUnit 8, CakePHP 4.0 and CakePHP 4.1. The same name as the rules is being used, mainly to avoid further changes in console command and documentation.
 
Last, PHPUnit version was needed to increase to v9, due to the introduction of sebastian/diff v4 dependency in rector v0.9