### PR TITLE
Specify 3.x branch checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ Upgrade tools for CakePHP meant to facilitate migrating from CakePHP 2.x to 3.0.
 
 ## Installation
 
+First clone the 3.x branch of this repository:
+
+```bash
+git clone git://github.com/cakephp/upgrade
+git checkout -b 3.x
+```
+
 After downloading/cloning the upgrade tool, you need to install dependencies with `composer`
 
 ```bash


### PR DESCRIPTION
Since it is important to use the 3.x branch when upgrading to 3.x, this information should be added. I've also submitted a pull request to link to this branch directly from the 3.x docs.