### PR TITLE
Fix 3.x clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ Upgrade tools for CakePHP meant to facilitate migrating from CakePHP 2.x to 3.0.
 First clone the 3.x branch of this repository:
 
 ```bash
-git clone git://github.com/cakephp/upgrade
-git checkout -b 3.x
+git clone https://github.com/cakephp/upgrade.git -b 3.x
 ```
 
 After downloading/cloning the upgrade tool, you need to install dependencies with `composer`


### PR DESCRIPTION
Fixes https://github.com/cakephp/upgrade/issues/156.

https://github.com/cakephp/upgrade/pull/155 had wrong command. It cloned and checked out `master`, then created local `3.x` branch pointing at `master`.