### PR TITLE
Use minimum stability stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
             "OldApp\\": "tests/OldApp"
         }
     },
-    "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {
         "cs-check": "phpcs --colors --parallel=16 -p -s src/ tests/",


### PR DESCRIPTION
Fixes https://github.com/cakephp/upgrade/issues/166

I don't think we need minimum stability dev for anything. It can introduce weird dependency issues.