### PR TITLE
Upgrade to rector 0.10.21 and replace deprecated code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "require": {
         "cakephp/console": "^4.0",
-        "rector/rector": "~0.9"
+        "rector/rector": "~0.10.21"
     },
     "autoload": {
         "psr-4": {

--- a/config/rector/cakephp40.php
+++ b/config/rector/cakephp40.php
@@ -1,17 +1,9 @@
 <?php
-
 declare(strict_types=1);
 
-use Rector\Core\Configuration\Option;
-use Rector\Set\ValueObject\SetList;
+use Rector\CakePHP\Set\CakePHPSetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
-    // get parameters
-    $parameters = $containerConfigurator->parameters();
-
-    // Define what rule sets will be applied
-    $parameters->set(Option::SETS, [
-	    SetList::CAKEPHP_40,
-    ]);
+    $containerConfigurator->import(CakePHPSetList::CAKEPHP_40);
 };

--- a/config/rector/cakephp41.php
+++ b/config/rector/cakephp41.php
@@ -1,17 +1,9 @@
 <?php
-
 declare(strict_types=1);
 
-use Rector\Core\Configuration\Option;
-use Rector\Set\ValueObject\SetList;
+use Rector\CakePHP\Set\CakePHPSetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
-    // get parameters
-    $parameters = $containerConfigurator->parameters();
-
-    // Define what rule sets will be applied
-    $parameters->set(Option::SETS, [
-	    SetList::CAKEPHP_41,
-    ]);
+    $containerConfigurator->import(CakePHPSetList::CAKEPHP_41);
 };

--- a/config/rector/cakephp42.php
+++ b/config/rector/cakephp42.php
@@ -1,17 +1,9 @@
 <?php
-
 declare(strict_types=1);
 
-use Rector\Core\Configuration\Option;
-use Rector\Set\ValueObject\SetList;
+use Rector\CakePHP\Set\CakePHPSetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
-    // get parameters
-    $parameters = $containerConfigurator->parameters();
-
-    // Define what rule sets will be applied
-    $parameters->set(Option::SETS, [
-	    SetList::CAKEPHP_42,
-    ]);
+    $containerConfigurator->import(CakePHPSetList::CAKEPHP_42);
 };

--- a/config/rector/phpunit80.php
+++ b/config/rector/phpunit80.php
@@ -1,17 +1,9 @@
 <?php
-
 declare(strict_types=1);
 
-use Rector\Core\Configuration\Option;
-use Rector\Set\ValueObject\SetList;
+use Rector\PHPUnit\Set\PHPUnitSetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
-    // get parameters
-    $parameters = $containerConfigurator->parameters();
-
-    // Define what rule sets will be applied
-    $parameters->set(Option::SETS, [
-	    SetList::PHPUNIT_80,
-    ]);
+    $containerConfigurator->import(PHPUnitSetList::PHPUNIT_80);
 };


### PR DESCRIPTION
Refs https://github.com/cakephp/upgrade/issues/169
Refs https://github.com/cakephp/upgrade/pull/165

Locked version to only patch releases. We won't need to upgrade again until 4.3.

I don't know if this helps the other issues users were having with rector 0.10. I never got an example of the app code that was causing it. However, with the large number of patch releases in the 0.10.x series hard to say.