### PR TITLE
Update composer.json (3.x branch) for CakePHP plugin installer 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,5 @@
     "prefer-stable": true,
     "support": {
         "source": "https://github.com/cakephp/upgrade"
-    },
-    "scripts": {
-        "post-autoload-dump": "Cake\\Composer\\Installer\\PluginInstaller::postAutoloadDump"
     }
 }


### PR DESCRIPTION
As CakePHP plugin installer no longer requires the "post-autoload-dump" hook, remove it. Removes a warning when doing composer install.