### PR TITLE
 Move RectorCakePHP rules here 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "homepage": "http://cakephp.org",
     "license": "MIT",
     "require": {
+        "php": "^8.0",
         "cakephp/console": "^4.0",
         "nette/utils": "^3.2",
         "rector/rector": "dev-main",

--- a/composer.json
+++ b/composer.json
@@ -37,11 +37,5 @@
     },
     "support": {
         "source": "https://github.com/cakephp/upgrade"
-    },
-    "require-dev": {
-        "cakephp/cakephp": "^4.0",
-        "cakephp/cakephp-codesniffer": "^4.0",
-        "mikey179/vfsstream": "^1.6.8",
-        "phpunit/phpunit": "^9.3"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -35,12 +35,5 @@
     },
     "support": {
         "source": "https://github.com/cakephp/upgrade"
-    },
-    "extra": {
-        "rector": {
-            "includes": [
-                "config/config.php"
-            ]
-        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,13 @@
     "license": "MIT",
     "require": {
         "cakephp/console": "^4.0",
-        "rector/rector": "^0.14.5"
+        "rector/rector": "dev-main",
+        "webmozart/assert": "^1.11"
     },
     "autoload": {
         "psr-4": {
-            "Cake\\Upgrade\\": "src"
+            "Cake\\Upgrade\\": "src",
+            "Rector\\CakePHP\\": "src/RectorCakePHP"
         }
     },
     "autoload-dev": {
@@ -27,11 +29,20 @@
     "config": {
         "sort-packages": true,
         "allow-plugins": {
+            "cweagans/composer-patches": true,
+            "phpstan/extension-installer": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "rector/extension-installer": true
         }
     },
     "support": {
         "source": "https://github.com/cakephp/upgrade"
+    },
+    "extra": {
+        "rector": {
+            "includes": [
+                "config/config.php"
+            ]
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "license": "MIT",
     "require": {
         "cakephp/console": "^4.0",
+        "nette/utils": "^3.2",
         "rector/rector": "dev-main",
         "webmozart/assert": "^1.11"
     },

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,6 @@
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "cweagans/composer-patches": true,
-            "phpstan/extension-installer": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "rector/extension-installer": true
         }

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         "cakephp/console": "^4.0",
         "nette/utils": "^3.2",
         "rector/rector": "dev-main",
+        "symfony/string": "^6.0",
         "webmozart/assert": "^1.11"
     },
     "autoload": {
@@ -36,5 +37,11 @@
     },
     "support": {
         "source": "https://github.com/cakephp/upgrade"
+    },
+    "require-dev": {
+        "cakephp/cakephp": "^4.0",
+        "cakephp/cakephp-codesniffer": "^4.0",
+        "mikey179/vfsstream": "^1.6.8",
+        "phpunit/phpunit": "^9.3"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Cake\\Upgrade\\Test\\": "tests"
+            "Cake\\Upgrade\\Test\\": "tests",
+            "Rector\\CakePHP\\Tests\\Rector\\": "tests/Rector"
         }
     },
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "php": "^8.0",
         "cakephp/console": "^4.0",
         "nette/utils": "^3.2",
-        "rector/rector": "dev-main",
+        "rector/rector": "^0.14.6",
         "symfony/string": "^6.0",
         "webmozart/assert": "^1.11"
     },

--- a/config/config.php
+++ b/config/config.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $services = $rectorConfig->services();
+
+    $services->defaults()
+        ->public()
+        ->autowire()
+        ->autoconfigure();
+
+    $services->load('Rector\\CakePHP\\', __DIR__ . '/../src/RectorCakePHP')
+        ->exclude([__DIR__ . '/../src/RectorCakePHP/{Rector,ValueObject,Contract}']);
+};

--- a/config/sets/cakephp-fluent-options.php
+++ b/config/sets/cakephp-fluent-options.php
@@ -9,7 +9,7 @@ use Rector\CakePHP\ValueObject\FactoryMethod;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-
+    $rectorConfig->import(__DIR__ . '/../config.php');
     $rectorConfig->ruleWithConfiguration(ArrayToFluentCallRector::class, [
         ArrayToFluentCallRector::ARRAYS_TO_FLUENT_CALLS => [
             new ArrayToFluentCall('Cake\ORM\Association', [

--- a/config/sets/cakephp-fluent-options.php
+++ b/config/sets/cakephp-fluent-options.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Rector\CakePHP\Rector\MethodCall\ArrayToFluentCallRector;
-
 use Rector\CakePHP\ValueObject\ArrayToFluentCall;
 use Rector\CakePHP\ValueObject\FactoryMethod;
 use Rector\Config\RectorConfig;

--- a/config/sets/cakephp-fluent-options.php
+++ b/config/sets/cakephp-fluent-options.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CakePHP\Rector\MethodCall\ArrayToFluentCallRector;
+
+use Rector\CakePHP\ValueObject\ArrayToFluentCall;
+use Rector\CakePHP\ValueObject\FactoryMethod;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+
+    $rectorConfig->ruleWithConfiguration(ArrayToFluentCallRector::class, [
+        ArrayToFluentCallRector::ARRAYS_TO_FLUENT_CALLS => [
+            new ArrayToFluentCall('Cake\ORM\Association', [
+                'bindingKey' => 'setBindingKey',
+                'cascadeCallbacks' => 'setCascadeCallbacks',
+                'className' => 'setClassName',
+                'conditions' => 'setConditions',
+                'dependent' => 'setDependent',
+                'finder' => 'setFinder',
+                'foreignKey' => 'setForeignKey',
+                'joinType' => 'setJoinType',
+                'propertyName' => 'setProperty',
+                'sourceTable' => 'setSource',
+                'strategy' => 'setStrategy',
+                'targetTable' => 'setTarget',
+                # BelongsToMany and HasMany only
+                'saveStrategy' => 'setSaveStrategy',
+                'sort' => 'setSort',
+                # BelongsToMany only
+                'targetForeignKey' => 'setTargetForeignKey',
+                'through' => 'setThrough',
+            ]),
+            new ArrayToFluentCall('Cake\ORM\Query', [
+                'fields' => 'select',
+                'conditions' => 'where',
+                'join' => 'join',
+                'order' => 'order',
+                'limit' => 'limit',
+                'offset' => 'offset',
+                'group' => 'group',
+                'having' => 'having',
+                'contain' => 'contain',
+                'page' => 'page',
+            ]),
+            new ArrayToFluentCall('Cake\ORM\Association', [
+                'bindingKey' => 'setBindingKey',
+                'cascadeCallbacks' => 'setCascadeCallbacks',
+                'className' => 'setClassName',
+                'conditions' => 'setConditions',
+                'dependent' => 'setDependent',
+                'finder' => 'setFinder',
+                'foreignKey' => 'setForeignKey',
+                'joinType' => 'setJoinType',
+                'propertyName' => 'setProperty',
+                'sourceTable' => 'setSource',
+                'strategy' => 'setStrategy',
+                'targetTable' => 'setTarget',
+                # BelongsToMany and HasMany only
+                'saveStrategy' => 'setSaveStrategy',
+                'sort' => 'setSort',
+                # BelongsToMany only
+                'targetForeignKey' => 'setTargetForeignKey',
+                'through' => 'setThrough',
+            ]),
+            new ArrayToFluentCall('Cake\ORM\Query', [
+                'fields' => 'select',
+                'conditions' => 'where',
+                'join' => 'join',
+                'order' => 'order',
+                'limit' => 'limit',
+                'offset' => 'offset',
+                'group' => 'group',
+                'having' => 'having',
+                'contain' => 'contain',
+                'page' => 'page',
+            ]),
+        ],
+        ArrayToFluentCallRector::FACTORY_METHODS => [
+            new FactoryMethod('Cake\ORM\Table', 'belongsTo', 'Cake\ORM\Association', 2),
+            new FactoryMethod('Cake\ORM\Table', 'belongsToMany', 'Cake\ORM\Association', 2),
+            new FactoryMethod('Cake\ORM\Table', 'hasMany', 'Cake\ORM\Association', 2),
+            new FactoryMethod('Cake\ORM\Table', 'hasOne', 'Cake\ORM\Association', 2),
+            new FactoryMethod('Cake\ORM\Table', 'find', 'Cake\ORM\Query', 2),
+        ],
+    ]);
+};

--- a/config/sets/cakephp30.php
+++ b/config/sets/cakephp30.php
@@ -8,7 +8,7 @@ use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 
 return static function (RectorConfig $rectorConfig): void {
-
+    $rectorConfig->import(__DIR__ . '/../config.php');
     # @see https://github.com/cakephp/upgrade/tree/master/src/Shell/Task
     $rectorConfig->rule(AppUsesStaticCallToUseStatementRector::class);
 

--- a/config/sets/cakephp30.php
+++ b/config/sets/cakephp30.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Rector\CakePHP\Rector\Namespace_\AppUsesStaticCallToUseStatementRector;
-
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 

--- a/config/sets/cakephp30.php
+++ b/config/sets/cakephp30.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CakePHP\Rector\Namespace_\AppUsesStaticCallToUseStatementRector;
+
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+
+return static function (RectorConfig $rectorConfig): void {
+
+    # @see https://github.com/cakephp/upgrade/tree/master/src/Shell/Task
+    $rectorConfig->rule(AppUsesStaticCallToUseStatementRector::class);
+
+    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
+        # see https://github.com/cakephp/upgrade/blob/756410c8b7d5aff9daec3fa1fe750a3858d422ac/src/Shell/Task/RenameClassesTask.php#L37
+        'Cake\Network\Http\HttpSocket' => 'Cake\Network\Http\Client',
+        'Cake\Model\ConnectionManager' => 'Cake\Database\ConnectionManager',
+        'Cake\TestSuite\CakeTestCase' => 'Cake\TestSuite\TestCase',
+        'Cake\TestSuite\Fixture\CakeTestFixture' => 'Cake\TestSuite\Fixture\TestFixture',
+        'Cake\Utility\String' => 'Cake\Utility\Text',
+        'CakePlugin' => 'Plugin',
+        'CakeException' => 'Exception',
+        # see https://book.cakephp.org/3/en/appendices/3-0-migration-guide.html#configure
+        'Cake\Configure\PhpReader' => 'Cake\Core\Configure\EnginePhpConfig',
+        'Cake\Configure\IniReader' => 'Cake\Core\Configure\EngineIniConfig',
+        'Cake\Configure\ConfigReaderInterface' => 'Cake\Core\Configure\ConfigEngineInterface',
+        # https://book.cakephp.org/3/en/appendices/3-0-migration-guide.html#request
+        'CakeRequest' => 'Cake\Network\Request',
+    ]);
+};

--- a/config/sets/cakephp34.php
+++ b/config/sets/cakephp34.php
@@ -18,7 +18,7 @@ use Rector\Visibility\Rector\ClassMethod\ChangeMethodVisibilityRector;
 use Rector\Visibility\ValueObject\ChangeMethodVisibility;
 
 return static function (RectorConfig $rectorConfig): void {
-
+    $rectorConfig->import(__DIR__ . '/../config.php');
     $rectorConfig->ruleWithConfiguration(PropertyFetchToMethodCallRector::class, [
         // source: https://book.cakephp.org/3.0/en/appendices/3-4-migration-guide.html
         new PropertyFetchToMethodCall('Cake\Network\Request', 'params', 'getAttribute', null, ['params']),

--- a/config/sets/cakephp34.php
+++ b/config/sets/cakephp34.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Rector\CakePHP\Rector\MethodCall\ModalToGetSetRector;
-
 use Rector\CakePHP\ValueObject\ModalToGetSet;
 use Rector\Config\RectorConfig;
 use Rector\Core\ValueObject\Visibility;

--- a/config/sets/cakephp34.php
+++ b/config/sets/cakephp34.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CakePHP\Rector\MethodCall\ModalToGetSetRector;
+
+use Rector\CakePHP\ValueObject\ModalToGetSet;
+use Rector\Config\RectorConfig;
+use Rector\Core\ValueObject\Visibility;
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+use Rector\Renaming\Rector\PropertyFetch\RenamePropertyRector;
+use Rector\Renaming\ValueObject\MethodCallRename;
+use Rector\Renaming\ValueObject\RenameProperty;
+use Rector\Transform\Rector\Assign\PropertyFetchToMethodCallRector;
+use Rector\Transform\ValueObject\PropertyFetchToMethodCall;
+use Rector\Visibility\Rector\ClassMethod\ChangeMethodVisibilityRector;
+use Rector\Visibility\ValueObject\ChangeMethodVisibility;
+
+return static function (RectorConfig $rectorConfig): void {
+
+    $rectorConfig->ruleWithConfiguration(PropertyFetchToMethodCallRector::class, [
+        // source: https://book.cakephp.org/3.0/en/appendices/3-4-migration-guide.html
+        new PropertyFetchToMethodCall('Cake\Network\Request', 'params', 'getAttribute', null, ['params']),
+        new PropertyFetchToMethodCall('Cake\Network\Request', 'data', 'getData'),
+        new PropertyFetchToMethodCall('Cake\Network\Request', 'query', 'getQueryParams'),
+        new PropertyFetchToMethodCall('Cake\Network\Request', 'cookies', 'getCookie'),
+        new PropertyFetchToMethodCall('Cake\Network\Request', 'base', 'getAttribute', null, ['base']),
+        new PropertyFetchToMethodCall('Cake\Network\Request', 'webroot', 'getAttribute', null, ['webroot']),
+        new PropertyFetchToMethodCall('Cake\Network\Request', 'here', 'getAttribute', null, ['here']),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(
+        RenamePropertyRector::class,
+        [new RenameProperty('Cake\Network\Request', '_session', 'session')]
+    );
+
+    $rectorConfig->ruleWithConfiguration(ModalToGetSetRector::class, [
+        new ModalToGetSet('Cake\Core\InstanceConfigTrait', 'config', null, null, 2, 'array'),
+        new ModalToGetSet('Cake\Core\StaticConfigTrait', 'config', null, null, 2, 'array'),
+        new ModalToGetSet('Cake\Console\ConsoleOptionParser', 'command'),
+        new ModalToGetSet('Cake\Console\ConsoleOptionParser', 'description'),
+        new ModalToGetSet('Cake\Console\ConsoleOptionParser', 'epilog'),
+        new ModalToGetSet('Cake\Database\Connection', 'driver'),
+        new ModalToGetSet('Cake\Database\Connection', 'schemaCollection'),
+        new ModalToGetSet('Cake\Database\Connection', 'useSavePoints', 'isSavePointsEnabled', 'enableSavePoints'),
+        new ModalToGetSet('Cake\Database\Driver', 'autoQuoting', 'isAutoQuotingEnabled', 'enableAutoQuoting'),
+        new ModalToGetSet('Cake\Database\Expression\FunctionExpression', 'name'),
+        new ModalToGetSet(
+            'Cake\Database\Expression\QueryExpression',
+            'tieWith',
+            'getConjunction',
+            'setConjunction'
+        ),
+        new ModalToGetSet('Cake\Database\Expression\ValuesExpression', 'columns'),
+        new ModalToGetSet('Cake\Database\Expression\ValuesExpression', 'values'),
+        new ModalToGetSet('Cake\Database\Expression\ValuesExpression', 'query'),
+        new ModalToGetSet('Cake\Database\Query', 'connection'),
+        new ModalToGetSet('Cake\Database\Query', 'selectTypeMap'),
+        new ModalToGetSet(
+            'Cake\Database\Query',
+            'bufferResults',
+            'isBufferedResultsEnabled',
+            'enableBufferedResults'
+        ),
+        new ModalToGetSet('Cake\Database\Schema\CachedCollection', 'cacheMetadata'),
+        new ModalToGetSet('Cake\Database\Schema\TableSchema', 'options'),
+        new ModalToGetSet('Cake\Database\Schema\TableSchema', 'temporary', 'isTemporary', 'setTemporary'),
+        new ModalToGetSet('Cake\Database\TypeMap', 'defaults'),
+        new ModalToGetSet('Cake\Database\TypeMap', 'types'),
+        new ModalToGetSet('Cake\Database\TypeMapTrait', 'typeMap'),
+        new ModalToGetSet('Cake\Database\TypeMapTrait', 'defaultTypes'),
+        new ModalToGetSet('Cake\ORM\Association', 'name'),
+        new ModalToGetSet('Cake\ORM\Association', 'cascadeCallbacks'),
+        new ModalToGetSet('Cake\ORM\Association', 'source'),
+        new ModalToGetSet('Cake\ORM\Association', 'target'),
+        new ModalToGetSet('Cake\ORM\Association', 'conditions'),
+        new ModalToGetSet('Cake\ORM\Association', 'bindingKey'),
+        new ModalToGetSet('Cake\ORM\Association', 'foreignKey'),
+        new ModalToGetSet('Cake\ORM\Association', 'dependent'),
+        new ModalToGetSet('Cake\ORM\Association', 'joinType'),
+        new ModalToGetSet('Cake\ORM\Association', 'property'),
+        new ModalToGetSet('Cake\ORM\Association', 'strategy'),
+        new ModalToGetSet('Cake\ORM\Association', 'finder'),
+        new ModalToGetSet('Cake\ORM\Association\BelongsToMany', 'targetForeignKey'),
+        new ModalToGetSet('Cake\ORM\Association\BelongsToMany', 'saveStrategy'),
+        new ModalToGetSet('Cake\ORM\Association\BelongsToMany', 'conditions'),
+        new ModalToGetSet('Cake\ORM\Association\HasMany', 'saveStrategy'),
+        new ModalToGetSet('Cake\ORM\Association\HasMany', 'foreignKey'),
+        new ModalToGetSet('Cake\ORM\Association\HasMany', 'sort'),
+        new ModalToGetSet('Cake\ORM\Association\HasOne', 'foreignKey'),
+        new ModalToGetSet('Cake\ORM\EagerLoadable', 'config'),
+        new ModalToGetSet('Cake\ORM\EagerLoadable', 'canBeJoined', 'canBeJoined', 'setCanBeJoined'),
+
+        // note: will have to be called after setMatching() to keep the old behavior
+        // ref: https://github.com/cakephp/cakephp/blob/4feee5463641e05c068b4d1d31dc5ee882b4240f/src/ORM/EagerLoader.php#L330
+        new ModalToGetSet('Cake\ORM\EagerLoadable', 'matching'),
+        new ModalToGetSet('Cake\ORM\EagerLoadable', 'autoFields', 'isAutoFieldsEnabled', 'enableAutoFields'),
+        new ModalToGetSet('Cake\ORM\Locator\TableLocator', 'config'),
+        new ModalToGetSet('Cake\ORM\Query', 'eagerLoader'),
+        new ModalToGetSet('Cake\ORM\Query', 'hydrate', 'isHydrationEnabled', 'enableHydration'),
+        new ModalToGetSet('Cake\ORM\Query', 'autoFields', 'isAutoFieldsEnabled', 'enableAutoFields'),
+        new ModalToGetSet('Cake\ORM\Table', 'table'),
+        new ModalToGetSet('Cake\ORM\Table', 'alias'),
+        new ModalToGetSet('Cake\ORM\Table', 'registryAlias'),
+        new ModalToGetSet('Cake\ORM\Table', 'connection'),
+        new ModalToGetSet('Cake\ORM\Table', 'schema'),
+        new ModalToGetSet('Cake\ORM\Table', 'primaryKey'),
+        new ModalToGetSet('Cake\ORM\Table', 'displayField'),
+        new ModalToGetSet('Cake\ORM\Table', 'entityClass'),
+
+        new ModalToGetSet('Cake\Mailer\Email', 'entityClass'),
+
+        new ModalToGetSet('Cake\Mailer\Email', 'from'),
+        new ModalToGetSet('Cake\Mailer\Email', 'sender'),
+        new ModalToGetSet('Cake\Mailer\Email', 'replyTo'),
+        new ModalToGetSet('Cake\Mailer\Email', 'readReceipt'),
+        new ModalToGetSet('Cake\Mailer\Email', 'returnPath'),
+        new ModalToGetSet('Cake\Mailer\Email', 'to'),
+        new ModalToGetSet('Cake\Mailer\Email', 'cc'),
+        new ModalToGetSet('Cake\Mailer\Email', 'bcc'),
+        new ModalToGetSet('Cake\Mailer\Email', 'charset'),
+        new ModalToGetSet('Cake\Mailer\Email', 'headerCharset'),
+        new ModalToGetSet('Cake\Mailer\Email', 'emailPattern'),
+        new ModalToGetSet('Cake\Mailer\Email', 'subject'),
+        // template: have to be changed manually, non A → B change + array case
+        new ModalToGetSet('Cake\Mailer\Email', 'viewRender', 'getViewRenderer', 'setViewRenderer'),
+        new ModalToGetSet('Cake\Mailer\Email', 'viewVars'),
+        new ModalToGetSet('Cake\Mailer\Email', 'theme'),
+        new ModalToGetSet('Cake\Mailer\Email', 'helpers'),
+        new ModalToGetSet('Cake\Mailer\Email', 'emailFormat'),
+        new ModalToGetSet('Cake\Mailer\Email', 'transport'),
+        new ModalToGetSet('Cake\Mailer\Email', 'messageId'),
+        new ModalToGetSet('Cake\Mailer\Email', 'domain'),
+        new ModalToGetSet('Cake\Mailer\Email', 'attachments'),
+        new ModalToGetSet('Cake\Mailer\Email', 'configTransport'),
+        new ModalToGetSet('Cake\Mailer\Email', 'profile'),
+        new ModalToGetSet('Cake\Validation\Validator', 'provider'),
+        new ModalToGetSet('Cake\View\StringTemplateTrait', 'templates'),
+        new ModalToGetSet('Cake\View\ViewBuilder', 'templatePath'),
+        new ModalToGetSet('Cake\View\ViewBuilder', 'layoutPath'),
+        new ModalToGetSet('Cake\View\ViewBuilder', 'plugin'),
+        new ModalToGetSet('Cake\View\ViewBuilder', 'helpers'),
+        new ModalToGetSet('Cake\View\ViewBuilder', 'theme'),
+        new ModalToGetSet('Cake\View\ViewBuilder', 'template'),
+        new ModalToGetSet('Cake\View\ViewBuilder', 'layout'),
+        new ModalToGetSet('Cake\View\ViewBuilder', 'options'),
+        new ModalToGetSet('Cake\View\ViewBuilder', 'name'),
+        new ModalToGetSet('Cake\View\ViewBuilder', 'className'),
+        new ModalToGetSet('Cake\View\ViewBuilder', 'autoLayout', 'isAutoLayoutEnabled', 'enableAutoLayout'),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(RenameMethodRector::class, [
+        new MethodCallRename('Cake\Network\Request', 'param', 'getParam'),
+        new MethodCallRename('Cake\Network\Request', 'data', 'getData'),
+        new MethodCallRename('Cake\Network\Request', 'query', 'getQuery'),
+        new MethodCallRename('Cake\Network\Request', 'cookie', 'getCookie'),
+        new MethodCallRename('Cake\Network\Request', 'method', 'getMethod'),
+        new MethodCallRename('Cake\Network\Request', 'setInput', 'withBody'),
+        new MethodCallRename('Cake\Network\Response', 'location', 'withLocation'),
+        new MethodCallRename('Cake\Network\Response', 'disableCache', 'withDisabledCache'),
+        new MethodCallRename('Cake\Network\Response', 'type', 'withType'),
+        new MethodCallRename('Cake\Network\Response', 'charset', 'withCharset'),
+        new MethodCallRename('Cake\Network\Response', 'cache', 'withCache'),
+        new MethodCallRename('Cake\Network\Response', 'modified', 'withModified'),
+        new MethodCallRename('Cake\Network\Response', 'expires', 'withExpires'),
+        new MethodCallRename('Cake\Network\Response', 'sharable', 'withSharable'),
+        new MethodCallRename('Cake\Network\Response', 'maxAge', 'withMaxAge'),
+        new MethodCallRename('Cake\Network\Response', 'vary', 'withVary'),
+        new MethodCallRename('Cake\Network\Response', 'etag', 'withEtag'),
+        new MethodCallRename('Cake\Network\Response', 'compress', 'withCompression'),
+        new MethodCallRename('Cake\Network\Response', 'length', 'withLength'),
+        new MethodCallRename('Cake\Network\Response', 'mustRevalidate', 'withMustRevalidate'),
+        new MethodCallRename('Cake\Network\Response', 'notModified', 'withNotModified'),
+        new MethodCallRename('Cake\Network\Response', 'cookie', 'withCookie'),
+        new MethodCallRename('Cake\Network\Response', 'file', 'withFile'),
+        new MethodCallRename('Cake\Network\Response', 'download', 'withDownload'),
+        # psr-7
+        new MethodCallRename('Cake\Network\Response', 'header', 'getHeader'),
+        new MethodCallRename('Cake\Network\Response', 'body', 'withBody'),
+        new MethodCallRename('Cake\Network\Response', 'statusCode', 'getStatusCode'),
+        new MethodCallRename('Cake\Network\Response', 'protocol', 'getProtocolVersion'),
+        new MethodCallRename('Cake\Event\Event', 'name', 'getName'),
+        new MethodCallRename('Cake\Event\Event', 'subject', 'getSubject'),
+        new MethodCallRename('Cake\Event\Event', 'result', 'getResult'),
+        new MethodCallRename('Cake\Event\Event', 'data', 'getData'),
+        new MethodCallRename('Cake\View\Helper\FormHelper', 'input', 'control'),
+        new MethodCallRename('Cake\View\Helper\FormHelper', 'inputs', 'controls'),
+        new MethodCallRename('Cake\View\Helper\FormHelper', 'allInputs', 'allControls'),
+        new MethodCallRename('Cake\Mailer\Mailer', 'layout', 'setLayout'),
+        new MethodCallRename('Cake\Routing\Route\Route', 'parse', 'parseRequest'),
+        new MethodCallRename('Cake\Routing\Router', 'parse', 'parseRequest'),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(ChangeMethodVisibilityRector::class, [
+        new ChangeMethodVisibility('Cake\Mailer\MailerAwareTrait', 'getMailer', Visibility::PROTECTED),
+        new ChangeMethodVisibility('Cake\View\CellTrait', 'cell', Visibility::PROTECTED),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
+        'Cake\Database\Schema\Table' => 'Cake\Database\Schema\TableSchema',
+    ]);
+};

--- a/config/sets/cakephp35.php
+++ b/config/sets/cakephp35.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CakePHP\Rector\MethodCall\ModalToGetSetRector;
+
+use Rector\CakePHP\ValueObject\ModalToGetSet;
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+use Rector\Renaming\ValueObject\MethodCallRename;
+
+# source: https://book.cakephp.org/3.0/en/appendices/3-5-migration-guide.html
+return static function (RectorConfig $rectorConfig): void {
+
+    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
+        'Cake\Http\Client\CookieCollection' => 'Cake\Http\Cookie\CookieCollection',
+        'Cake\Console\ShellDispatcher' => 'Cake\Console\CommandRunner',
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(RenameMethodRector::class, [
+        new MethodCallRename('Cake\Database\Schema\TableSchema', 'column', 'getColumn'),
+        new MethodCallRename('Cake\Database\Schema\TableSchema', 'constraint', 'getConstraint'),
+        new MethodCallRename('Cake\Database\Schema\TableSchema', 'index', 'getIndex'),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(ModalToGetSetRector::class, [
+        new ModalToGetSet('Cake\Cache\Cache', 'config'),
+        new ModalToGetSet('Cake\Cache\Cache', 'registry'),
+        new ModalToGetSet('Cake\Console\Shell', 'io'),
+        new ModalToGetSet('Cake\Console\ConsoleIo', 'outputAs'),
+        new ModalToGetSet('Cake\Console\ConsoleOutput', 'outputAs'),
+        new ModalToGetSet('Cake\Database\Connection', 'logger'),
+        new ModalToGetSet('Cake\Database\TypedResultInterface', 'returnType'),
+        new ModalToGetSet('Cake\Database\TypedResultTrait', 'returnType'),
+        new ModalToGetSet('Cake\Database\Log\LoggingStatement', 'logger'),
+        new ModalToGetSet('Cake\Datasource\ModelAwareTrait', 'modelType'),
+        new ModalToGetSet('Cake\Database\Query', 'valueBinder', 'getValueBinder', 'valueBinder'),
+        new ModalToGetSet('Cake\Database\Schema\TableSchema', 'columnType'),
+        new ModalToGetSet('Cake\Datasource\QueryTrait', 'eagerLoaded', 'isEagerLoaded', 'eagerLoaded'),
+        new ModalToGetSet('Cake\Event\EventDispatcherInterface', 'eventManager'),
+        new ModalToGetSet('Cake\Event\EventDispatcherTrait', 'eventManager'),
+        new ModalToGetSet('Cake\Error\Debugger', 'outputAs', 'getOutputFormat', 'setOutputFormat'),
+        new ModalToGetSet('Cake\Http\ServerRequest', 'env', 'getEnv', 'withEnv'),
+        new ModalToGetSet('Cake\Http\ServerRequest', 'charset', 'getCharset', 'withCharset'),
+        new ModalToGetSet('Cake\I18n\I18n', 'locale'),
+        new ModalToGetSet('Cake\I18n\I18n', 'translator'),
+        new ModalToGetSet('Cake\I18n\I18n', 'defaultLocale'),
+        new ModalToGetSet('Cake\I18n\I18n', 'defaultFormatter'),
+        new ModalToGetSet('Cake\ORM\Association\BelongsToMany', 'sort'),
+        new ModalToGetSet('Cake\ORM\LocatorAwareTrait', 'tableLocator'),
+        new ModalToGetSet('Cake\ORM\Table', 'validator'),
+        new ModalToGetSet('Cake\Routing\RouteBuilder', 'extensions'),
+        new ModalToGetSet('Cake\Routing\RouteBuilder', 'routeClass'),
+        new ModalToGetSet('Cake\Routing\RouteCollection', 'extensions'),
+        new ModalToGetSet('Cake\TestSuite\TestFixture', 'schema'),
+        new ModalToGetSet('Cake\Utility\Security', 'salt'),
+        new ModalToGetSet('Cake\View\View', 'template'),
+        new ModalToGetSet('Cake\View\View', 'layout'),
+        new ModalToGetSet('Cake\View\View', 'theme'),
+        new ModalToGetSet('Cake\View\View', 'templatePath'),
+        new ModalToGetSet('Cake\View\View', 'layoutPath'),
+        new ModalToGetSet('Cake\View\View', 'autoLayout', 'isAutoLayoutEnabled', 'enableAutoLayout'),
+    ]);
+};

--- a/config/sets/cakephp35.php
+++ b/config/sets/cakephp35.php
@@ -12,7 +12,7 @@ use Rector\Renaming\ValueObject\MethodCallRename;
 
 # source: https://book.cakephp.org/3.0/en/appendices/3-5-migration-guide.html
 return static function (RectorConfig $rectorConfig): void {
-
+    $rectorConfig->import(__DIR__ . '/../config.php');
     $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
         'Cake\Http\Client\CookieCollection' => 'Cake\Http\Cookie\CookieCollection',
         'Cake\Console\ShellDispatcher' => 'Cake\Console\CommandRunner',

--- a/config/sets/cakephp35.php
+++ b/config/sets/cakephp35.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Rector\CakePHP\Rector\MethodCall\ModalToGetSetRector;
-
 use Rector\CakePHP\ValueObject\ModalToGetSet;
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;

--- a/config/sets/cakephp36.php
+++ b/config/sets/cakephp36.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+use Rector\Renaming\ValueObject\MethodCallRename;
+use Rector\Transform\Rector\Assign\PropertyFetchToMethodCallRector;
+use Rector\Transform\ValueObject\PropertyFetchToMethodCall;
+
+return static function (RectorConfig $rectorConfig): void {
+
+    # source: https://book.cakephp.org/3.0/en/appendices/3-6-migration-guide.html
+    $rectorConfig->ruleWithConfiguration(RenameMethodRector::class, [
+        new MethodCallRename('Cake\ORM\Table', 'association', 'getAssociation'),
+        new MethodCallRename('Cake\Validation\ValidationSet', 'isPresenceRequired', 'requirePresence'),
+        new MethodCallRename('Cake\Validation\ValidationSet', 'isEmptyAllowed', 'allowEmpty'),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(PropertyFetchToMethodCallRector::class, [
+        new PropertyFetchToMethodCall('Cake\Controller\Controller', 'name', 'getName', 'setName'),
+        new PropertyFetchToMethodCall('Cake\Controller\Controller', 'plugin', 'getPlugin', 'setPlugin'),
+        new PropertyFetchToMethodCall('Cake\Form\Form', 'validator', 'getValidator', 'setValidator'),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
+        'Cake\Cache\Engine\ApcEngine' => 'Cake\Cache\Engine\ApcuEngine',
+        'Cake\Network\Exception\BadRequestException' => 'Cake\Http\Exception\BadRequestException',
+        'Cake\Network\Exception\ConflictException' => 'Cake\Http\Exception\ConflictException',
+        'Cake\Network\Exception\ForbiddenException' => 'Cake\Http\Exception\ForbiddenException',
+        'Cake\Network\Exception\GoneException' => 'Cake\Http\Exception\GoneException',
+        'Cake\Network\Exception\HttpException' => 'Cake\Http\Exception\HttpException',
+        'Cake\Network\Exception\InternalErrorException' => 'Cake\Http\Exception\InternalErrorException',
+        'Cake\Network\Exception\InvalidCsrfTokenException' => 'Cake\Http\Exception\InvalidCsrfTokenException',
+        'Cake\Network\Exception\MethodNotAllowedException' => 'Cake\Http\Exception\MethodNotAllowedException',
+        'Cake\Network\Exception\NotAcceptableException' => 'Cake\Http\Exception\NotAcceptableException',
+        'Cake\Network\Exception\NotFoundException' => 'Cake\Http\Exception\NotFoundException',
+        'Cake\Network\Exception\NotImplementedException' => 'Cake\Http\Exception\NotImplementedException',
+        'Cake\Network\Exception\ServiceUnavailableException' => 'Cake\Http\Exception\ServiceUnavailableException',
+        'Cake\Network\Exception\UnauthorizedException' => 'Cake\Http\Exception\UnauthorizedException',
+        'Cake\Network\Exception\UnavailableForLegalReasonsException' => 'Cake\Http\Exception\UnavailableForLegalReasonsException',
+        'Cake\Network\Session' => 'Cake\Http\Session',
+        'Cake\Network\Session\DatabaseSession' => 'Cake\Http\Session\DatabaseSession',
+        'Cake\Network\Session\CacheSession' => 'Cake\Http\Session\CacheSession',
+        'Cake\Network\CorsBuilder' => 'Cake\Http\CorsBuilder',
+        'Cake\View\Widget\WidgetRegistry' => 'Cake\View\Widget\WidgetLocator',
+    ]);
+};

--- a/config/sets/cakephp36.php
+++ b/config/sets/cakephp36.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
@@ -40,7 +39,8 @@ return static function (RectorConfig $rectorConfig): void {
         'Cake\Network\Exception\NotImplementedException' => 'Cake\Http\Exception\NotImplementedException',
         'Cake\Network\Exception\ServiceUnavailableException' => 'Cake\Http\Exception\ServiceUnavailableException',
         'Cake\Network\Exception\UnauthorizedException' => 'Cake\Http\Exception\UnauthorizedException',
-        'Cake\Network\Exception\UnavailableForLegalReasonsException' => 'Cake\Http\Exception\UnavailableForLegalReasonsException',
+        'Cake\Network\Exception\UnavailableForLegalReasonsException'
+            => 'Cake\Http\Exception\UnavailableForLegalReasonsException',
         'Cake\Network\Session' => 'Cake\Http\Session',
         'Cake\Network\Session\DatabaseSession' => 'Cake\Http\Session\DatabaseSession',
         'Cake\Network\Session\CacheSession' => 'Cake\Http\Session\CacheSession',

--- a/config/sets/cakephp36.php
+++ b/config/sets/cakephp36.php
@@ -11,7 +11,7 @@ use Rector\Transform\Rector\Assign\PropertyFetchToMethodCallRector;
 use Rector\Transform\ValueObject\PropertyFetchToMethodCall;
 
 return static function (RectorConfig $rectorConfig): void {
-
+    $rectorConfig->import(__DIR__ . '/../config.php');
     # source: https://book.cakephp.org/3.0/en/appendices/3-6-migration-guide.html
     $rectorConfig->ruleWithConfiguration(RenameMethodRector::class, [
         new MethodCallRename('Cake\ORM\Table', 'association', 'getAssociation'),

--- a/config/sets/cakephp37.php
+++ b/config/sets/cakephp37.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Rector\CakePHP\Rector\MethodCall\ModalToGetSetRector;
-
 use Rector\CakePHP\Rector\Property\ChangeSnakedFixtureNameToPascalRector;
 use Rector\CakePHP\ValueObject\ModalToGetSet;
 use Rector\Config\RectorConfig;

--- a/config/sets/cakephp37.php
+++ b/config/sets/cakephp37.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CakePHP\Rector\MethodCall\ModalToGetSetRector;
+
+use Rector\CakePHP\Rector\Property\ChangeSnakedFixtureNameToPascalRector;
+use Rector\CakePHP\ValueObject\ModalToGetSet;
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\ValueObject\MethodCallRename;
+use Rector\Transform\Rector\Assign\PropertyFetchToMethodCallRector;
+use Rector\Transform\Rector\MethodCall\MethodCallToAnotherMethodCallWithArgumentsRector;
+use Rector\Transform\ValueObject\MethodCallToAnotherMethodCallWithArguments;
+use Rector\Transform\ValueObject\PropertyFetchToMethodCall;
+
+# source: https://book.cakephp.org/3.0/en/appendices/3-7-migration-guide.html
+return static function (RectorConfig $rectorConfig): void {
+
+    $rectorConfig->ruleWithConfiguration(RenameMethodRector::class, [
+        new MethodCallRename('Cake\Form\Form', 'errors', 'getErrors'),
+        new MethodCallRename('Cake\Validation\Validation', 'cc', 'creditCard'),
+        new MethodCallRename('Cake\Filesystem\Folder', 'normalizePath', 'correctSlashFor'),
+        new MethodCallRename('Cake\Http\Client\Response', 'body', 'getStringBody'),
+        new MethodCallRename('Cake\Core\Plugin', 'unload', 'clear'),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(PropertyFetchToMethodCallRector::class, [
+        new PropertyFetchToMethodCall('Cake\Http\Client\Response', 'body', 'getStringBody'),
+        new PropertyFetchToMethodCall('Cake\Http\Client\Response', 'json', 'getJson'),
+        new PropertyFetchToMethodCall('Cake\Http\Client\Response', 'xml', 'getXml'),
+        new PropertyFetchToMethodCall('Cake\Http\Client\Response', 'cookies', 'getCookies'),
+        new PropertyFetchToMethodCall('Cake\Http\Client\Response', 'code', 'getStatusCode'),
+
+        new PropertyFetchToMethodCall('Cake\View\View', 'request', 'getRequest', 'setRequest'),
+        new PropertyFetchToMethodCall('Cake\View\View', 'response', 'getResponse', 'setResponse'),
+        new PropertyFetchToMethodCall('Cake\View\View', 'templatePath', 'getTemplatePath', 'setTemplatePath'),
+        new PropertyFetchToMethodCall('Cake\View\View', 'template', 'getTemplate', 'setTemplate'),
+        new PropertyFetchToMethodCall('Cake\View\View', 'layout', 'getLayout', 'setLayout'),
+        new PropertyFetchToMethodCall('Cake\View\View', 'layoutPath', 'getLayoutPath', 'setLayoutPath'),
+        new PropertyFetchToMethodCall('Cake\View\View', 'autoLayout', 'isAutoLayoutEnabled', 'enableAutoLayout'),
+        new PropertyFetchToMethodCall('Cake\View\View', 'theme', 'getTheme', 'setTheme'),
+        new PropertyFetchToMethodCall('Cake\View\View', 'subDir', 'getSubDir', 'setSubDir'),
+        new PropertyFetchToMethodCall('Cake\View\View', 'plugin', 'getPlugin', 'setPlugin'),
+        new PropertyFetchToMethodCall('Cake\View\View', 'name', 'getName', 'setName'),
+        new PropertyFetchToMethodCall('Cake\View\View', 'elementCache', 'getElementCache', 'setElementCache'),
+        new PropertyFetchToMethodCall('Cake\View\View', 'helpers', 'helpers'),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(MethodCallToAnotherMethodCallWithArgumentsRector::class, [
+        new MethodCallToAnotherMethodCallWithArguments('Cake\Database\Query', 'join', 'clause', ['join']),
+        new MethodCallToAnotherMethodCallWithArguments('Cake\Database\Query', 'from', 'clause', ['from']),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(ModalToGetSetRector::class, [
+        new ModalToGetSet('Cake\Database\Connection', 'logQueries', 'isQueryLoggingEnabled', 'enableQueryLogging'),
+        new ModalToGetSet('Cake\ORM\Association', 'className', 'getClassName', 'setClassName'),
+    ]);
+
+    $rectorConfig->rule(ChangeSnakedFixtureNameToPascalRector::class);
+};

--- a/config/sets/cakephp37.php
+++ b/config/sets/cakephp37.php
@@ -16,7 +16,7 @@ use Rector\Transform\ValueObject\PropertyFetchToMethodCall;
 
 # source: https://book.cakephp.org/3.0/en/appendices/3-7-migration-guide.html
 return static function (RectorConfig $rectorConfig): void {
-
+    $rectorConfig->import(__DIR__ . '/../config.php');
     $rectorConfig->ruleWithConfiguration(RenameMethodRector::class, [
         new MethodCallRename('Cake\Form\Form', 'errors', 'getErrors'),
         new MethodCallRename('Cake\Validation\Validation', 'cc', 'creditCard'),

--- a/config/sets/cakephp38.php
+++ b/config/sets/cakephp38.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
 

--- a/config/sets/cakephp38.php
+++ b/config/sets/cakephp38.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\ValueObject\MethodCallRename;
+
+# source: https://book.cakephp.org/3.0/en/appendices/3-8-migration-guide.html
+
+return static function (RectorConfig $rectorConfig): void {
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameMethodRector::class,
+        [new MethodCallRename('Cake\ORM\Entity', 'visibleProperties', 'getVisible')]
+    );
+};

--- a/config/sets/cakephp38.php
+++ b/config/sets/cakephp38.php
@@ -10,7 +10,7 @@ use Rector\Renaming\ValueObject\MethodCallRename;
 # source: https://book.cakephp.org/3.0/en/appendices/3-8-migration-guide.html
 
 return static function (RectorConfig $rectorConfig): void {
-
+    $rectorConfig->import(__DIR__ . '/../config.php');
     $rectorConfig->ruleWithConfiguration(
         RenameMethodRector::class,
         [new MethodCallRename('Cake\ORM\Entity', 'visibleProperties', 'getVisible')]

--- a/config/sets/cakephp40.php
+++ b/config/sets/cakephp40.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPStan\Type\BooleanType;
-
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;

--- a/config/sets/cakephp40.php
+++ b/config/sets/cakephp40.php
@@ -33,7 +33,7 @@ use Rector\TypeDeclaration\ValueObject\AddReturnTypeDeclaration;
 # source: https://book.cakephp.org/4/en/appendices/4-0-migration-guide.html
 
 return static function (RectorConfig $rectorConfig): void {
-
+    $rectorConfig->import(__DIR__ . '/../config.php');
     $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
         'Cake\Database\Type' => 'Cake\Database\TypeFactory',
         'Cake\Console\ConsoleErrorHandler' => 'Cake\Error\ConsoleErrorHandler',

--- a/config/sets/cakephp40.php
+++ b/config/sets/cakephp40.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPStan\Type\BooleanType;
+
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\UnionType;
+use PHPStan\Type\VoidType;
+use Rector\CakePHP\Rector\MethodCall\ModalToGetSetRector;
+use Rector\CakePHP\Rector\MethodCall\RenameMethodCallBasedOnParameterRector;
+use Rector\CakePHP\ValueObject\ModalToGetSet;
+use Rector\CakePHP\ValueObject\RenameMethodCallBasedOnParameter;
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\ClassConstFetch\RenameClassConstFetchRector;
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+use Rector\Renaming\Rector\PropertyFetch\RenamePropertyRector;
+use Rector\Renaming\Rector\StaticCall\RenameStaticMethodRector;
+use Rector\Renaming\ValueObject\MethodCallRename;
+use Rector\Renaming\ValueObject\RenameClassAndConstFetch;
+use Rector\Renaming\ValueObject\RenameClassConstFetch;
+use Rector\Renaming\ValueObject\RenameProperty;
+use Rector\Renaming\ValueObject\RenameStaticMethod;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddParamTypeDeclarationRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector;
+use Rector\TypeDeclaration\ValueObject\AddParamTypeDeclaration;
+use Rector\TypeDeclaration\ValueObject\AddReturnTypeDeclaration;
+
+# source: https://book.cakephp.org/4/en/appendices/4-0-migration-guide.html
+
+return static function (RectorConfig $rectorConfig): void {
+
+    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
+        'Cake\Database\Type' => 'Cake\Database\TypeFactory',
+        'Cake\Console\ConsoleErrorHandler' => 'Cake\Error\ConsoleErrorHandler',
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(RenameClassConstFetchRector::class, [
+        new RenameClassConstFetch('Cake\View\View', 'NAME_ELEMENT', 'TYPE_ELEMENT'),
+        new RenameClassConstFetch('Cake\View\View', 'NAME_LAYOUT', 'TYPE_LAYOUT'),
+        new RenameClassAndConstFetch('Cake\Mailer\Email', 'MESSAGE_HTML', 'Cake\Mailer\Message', 'MESSAGE_HTML'),
+        new RenameClassAndConstFetch('Cake\Mailer\Email', 'MESSAGE_TEXT', 'Cake\Mailer\Message', 'MESSAGE_TEXT'),
+        new RenameClassAndConstFetch('Cake\Mailer\Email', 'MESSAGE_BOTH', 'Cake\Mailer\Message', 'MESSAGE_BOTH'),
+        new RenameClassAndConstFetch('Cake\Mailer\Email', 'EMAIL_PATTERN', 'Cake\Mailer\Message', 'EMAIL_PATTERN'),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(RenameMethodRector::class, [
+        new MethodCallRename('Cake\Form\Form', 'errors', 'getErrors'),
+        new MethodCallRename('Cake\Mailer\Email', 'set', 'setViewVars'),
+        new MethodCallRename('Cake\ORM\EntityInterface', 'unsetProperty', 'unset'),
+        new MethodCallRename('Cake\Cache\Cache', 'engine', 'pool'),
+        new MethodCallRename('Cake\Http\Cookie\Cookie', 'getStringValue', 'getScalarValue'),
+        new MethodCallRename('Cake\Validation\Validator', 'containsNonAlphaNumeric', 'notAlphaNumeric'),
+        new MethodCallRename('Cake\Validation\Validator', 'errors', 'validate'),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(RenameStaticMethodRector::class, [
+        new RenameStaticMethod('Router', 'pushRequest', 'Router', 'setRequest'),
+        new RenameStaticMethod('Router', 'setRequestInfo', 'Router', 'setRequest'),
+        new RenameStaticMethod('Router', 'setRequestContext', 'Router', 'setRequest'),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(
+        RenamePropertyRector::class,
+        [new RenameProperty('Cake\ORM\Entity', '_properties', '_fields')]
+    );
+
+    $rectorConfig->ruleWithConfiguration(AddReturnTypeDeclarationRector::class, [
+        new AddReturnTypeDeclaration('Cake\Http\BaseApplication', 'bootstrap', new VoidType()),
+        new AddReturnTypeDeclaration('Cake\Http\BaseApplication', 'bootstrapCli', new VoidType()),
+        new AddReturnTypeDeclaration('Cake\Http\BaseApplication', 'middleware', new ObjectType(
+            'Cake\Http\MiddlewareQueue'
+        )),
+        new AddReturnTypeDeclaration('Cake\Console\Shell', 'initialize', new VoidType()),
+        new AddReturnTypeDeclaration('Cake\Controller\Component', 'initialize', new VoidType()),
+        new AddReturnTypeDeclaration('Cake\Controller\Controller', 'initialize', new VoidType()),
+        new AddReturnTypeDeclaration('Cake\Controller\Controller', 'render', new ObjectType('Cake\Http\Response')),
+        new AddReturnTypeDeclaration('Cake\Form\Form', 'validate', new BooleanType()),
+        new AddReturnTypeDeclaration('Cake\Form\Form', '_buildSchema', new ObjectType('Cake\Form\Schema')),
+        new AddReturnTypeDeclaration('Cake\ORM\Behavior', 'initialize', new VoidType()),
+        new AddReturnTypeDeclaration('Cake\ORM\Table', 'initialize', new VoidType()),
+        new AddReturnTypeDeclaration('Cake\ORM\Table', 'updateAll', new IntegerType()),
+        new AddReturnTypeDeclaration('Cake\ORM\Table', 'deleteAll', new IntegerType()),
+        new AddReturnTypeDeclaration('Cake\ORM\Table', 'validationDefault', new ObjectType(
+            'Cake\Validation\Validator'
+        )),
+        new AddReturnTypeDeclaration('Cake\ORM\Table', 'buildRules', new ObjectType('Cake\ORM\RulesChecker')),
+        new AddReturnTypeDeclaration('Cake\View\Helper', 'initialize', new VoidType()),
+    ]);
+
+    $eventInterfaceObjectType = new ObjectType('Cake\Event\EventInterface');
+
+    $rectorConfig->ruleWithConfiguration(AddParamTypeDeclarationRector::class, [
+        new AddParamTypeDeclaration(
+            'Cake\Form\Form',
+            'getData',
+            0,
+            new UnionType([new StringType(), new NullType()])
+        ),
+        new AddParamTypeDeclaration('Cake\ORM\Behavior', 'beforeFind', 0, $eventInterfaceObjectType),
+        new AddParamTypeDeclaration('Cake\ORM\Behavior', 'buildValidator', 0, $eventInterfaceObjectType),
+        new AddParamTypeDeclaration('Cake\ORM\Behavior', 'buildRules', 0, $eventInterfaceObjectType),
+        new AddParamTypeDeclaration('Cake\ORM\Behavior', 'beforeRules', 0, $eventInterfaceObjectType),
+        new AddParamTypeDeclaration('Cake\ORM\Behavior', 'afterRules', 0, $eventInterfaceObjectType),
+        new AddParamTypeDeclaration('Cake\ORM\Behavior', 'beforeSave', 0, $eventInterfaceObjectType),
+        new AddParamTypeDeclaration('Cake\ORM\Behavior', 'afterSave', 0, $eventInterfaceObjectType),
+        new AddParamTypeDeclaration('Cake\ORM\Behavior', 'beforeDelete', 0, $eventInterfaceObjectType),
+        new AddParamTypeDeclaration('Cake\ORM\Behavior', 'afterDelete', 0, $eventInterfaceObjectType),
+        new AddParamTypeDeclaration('Cake\ORM\Table', 'beforeFind', 0, $eventInterfaceObjectType),
+        new AddParamTypeDeclaration('Cake\ORM\Table', 'buildValidator', 0, $eventInterfaceObjectType),
+        new AddParamTypeDeclaration('Cake\ORM\Table', 'buildRules', 0, new ObjectType('Cake\ORM\RulesChecker')),
+        new AddParamTypeDeclaration('Cake\ORM\Table', 'beforeRules', 0, $eventInterfaceObjectType),
+        new AddParamTypeDeclaration('Cake\ORM\Table', 'afterRules', 0, $eventInterfaceObjectType),
+        new AddParamTypeDeclaration('Cake\ORM\Table', 'beforeSave', 0, $eventInterfaceObjectType),
+        new AddParamTypeDeclaration('Cake\ORM\Table', 'afterSave', 0, $eventInterfaceObjectType),
+        new AddParamTypeDeclaration('Cake\ORM\Table', 'beforeDelete', 0, $eventInterfaceObjectType),
+        new AddParamTypeDeclaration('Cake\ORM\Table', 'afterDelete', 0, $eventInterfaceObjectType),
+        new AddParamTypeDeclaration('Cake\Controller\Controller', 'beforeFilter', 0, $eventInterfaceObjectType),
+        new AddParamTypeDeclaration('Cake\Controller\Controller', 'afterFilter', 0, $eventInterfaceObjectType),
+        new AddParamTypeDeclaration('Cake\Controller\Controller', 'beforeRender', 0, $eventInterfaceObjectType),
+        new AddParamTypeDeclaration('Cake\Controller\Controller', 'beforeRedirect', 0, $eventInterfaceObjectType),
+        new AddParamTypeDeclaration('Cake\Controller\Component', 'shutdown', 0, $eventInterfaceObjectType),
+        new AddParamTypeDeclaration('Cake\Controller\Component', 'startup', 0, $eventInterfaceObjectType),
+        new AddParamTypeDeclaration('Cake\Controller\Component', 'beforeFilter', 0, $eventInterfaceObjectType),
+        new AddParamTypeDeclaration('Cake\Controller\Component', 'beforeRender', 0, $eventInterfaceObjectType),
+        new AddParamTypeDeclaration('Cake\Controller\Component', 'beforeRedirect', 0, $eventInterfaceObjectType),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(RenameMethodCallBasedOnParameterRector::class, [
+        new RenameMethodCallBasedOnParameter('Cake\Http\ServerRequest', 'getParam', 'paging', 'getAttribute'),
+        new RenameMethodCallBasedOnParameter('Cake\Http\ServerRequest', 'withParam', 'paging', 'withAttribute'),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(ModalToGetSetRector::class, [
+        new ModalToGetSet('Cake\Console\ConsoleIo', 'styles', 'setStyle', 'getStyle'),
+        new ModalToGetSet('Cake\Console\ConsoleOutput', 'styles', 'setStyle', 'getStyle'),
+        new ModalToGetSet('Cake\ORM\EntityInterface', 'isNew', 'setNew', 'isNew'),
+    ]);
+};

--- a/config/sets/cakephp41.php
+++ b/config/sets/cakephp41.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CakePHP\Rector\MethodCall\ModalToGetSetRector;
+
+use Rector\CakePHP\ValueObject\ModalToGetSet;
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+use Rector\Renaming\ValueObject\MethodCallRename;
+
+return static function (RectorConfig $rectorConfig): void {
+
+    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
+        'Cake\Routing\Exception\RedirectException' => 'Cake\Http\Exception\RedirectException',
+        'Cake\Database\Expression\Comparison' => 'Cake\Database\Expression\ComparisonExpression',
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(RenameMethodRector::class, [
+        new MethodCallRename('Cake\Database\Schema\TableSchema', 'getPrimary', 'getPrimaryKey'),
+        new MethodCallRename('Cake\Database\Type\DateTimeType', 'setTimezone', 'setDatabaseTimezone'),
+        new MethodCallRename('Cake\Database\Expression\QueryExpression', 'or_', 'or'),
+        new MethodCallRename('Cake\Database\Expression\QueryExpression', 'and_', 'and'),
+        new MethodCallRename('Cake\View\Form\ContextInterface', 'primaryKey', 'getPrimaryKey'),
+        new MethodCallRename(
+            'Cake\Http\Middleware\CsrfProtectionMiddleware',
+            'whitelistCallback',
+            'skipCheckCallback'
+        ),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(ModalToGetSetRector::class, [new ModalToGetSet('Cake\Form\Form', 'schema')]);
+};

--- a/config/sets/cakephp41.php
+++ b/config/sets/cakephp41.php
@@ -11,7 +11,7 @@ use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
 
 return static function (RectorConfig $rectorConfig): void {
-
+    $rectorConfig->import(__DIR__ . '/../config.php');
     $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
         'Cake\Routing\Exception\RedirectException' => 'Cake\Http\Exception\RedirectException',
         'Cake\Database\Expression\Comparison' => 'Cake\Database\Expression\ComparisonExpression',

--- a/config/sets/cakephp41.php
+++ b/config/sets/cakephp41.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Rector\CakePHP\Rector\MethodCall\ModalToGetSetRector;
-
 use Rector\CakePHP\ValueObject\ModalToGetSet;
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;

--- a/config/sets/cakephp42.php
+++ b/config/sets/cakephp42.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+use Rector\Renaming\ValueObject\MethodCallRename;
+
+# source: https://book.cakephp.org/4/en/appendices/4-2-migration-guide.html
+return static function (RectorConfig $rectorConfig): void {
+
+    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
+        'Cake\Core\Exception\Exception' => 'Cake\Core\Exception\CakeException',
+        'Cake\Database\Exception' => 'Cake\Database\Exception\DatabaseException',
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameMethodRector::class,
+        [new MethodCallRename('Cake\ORM\Behavior', 'getTable', 'table')]
+    );
+};

--- a/config/sets/cakephp42.php
+++ b/config/sets/cakephp42.php
@@ -10,7 +10,7 @@ use Rector\Renaming\ValueObject\MethodCallRename;
 
 # source: https://book.cakephp.org/4/en/appendices/4-2-migration-guide.html
 return static function (RectorConfig $rectorConfig): void {
-
+    $rectorConfig->import(__DIR__ . '/../config.php');
     $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
         'Cake\Core\Exception\Exception' => 'Cake\Core\Exception\CakeException',
         'Cake\Database\Exception' => 'Cake\Database\Exception\DatabaseException',

--- a/config/sets/cakephp42.php
+++ b/config/sets/cakephp42.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Renaming\ValueObject\MethodCallRename;

--- a/config/sets/cakephp43.php
+++ b/config/sets/cakephp43.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CakePHP\Rector\MethodCall\RemoveIntermediaryMethodRector;
+
+use Rector\CakePHP\ValueObject\RemoveIntermediaryMethod;
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\ValueObject\MethodCallRename;
+use Rector\Transform\Rector\Assign\PropertyFetchToMethodCallRector;
+use Rector\Transform\Rector\MethodCall\MethodCallToAnotherMethodCallWithArgumentsRector;
+use Rector\Transform\ValueObject\MethodCallToAnotherMethodCallWithArguments;
+use Rector\Transform\ValueObject\PropertyFetchToMethodCall;
+
+# source: https://book.cakephp.org/4.next/en/appendices/4-3-migration-guide.html
+return static function (RectorConfig $rectorConfig): void {
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameMethodRector::class,
+        [new MethodCallRename('Cake\Controller\Component', 'shutdown', 'afterFilter')]
+    );
+
+    $rectorConfig->ruleWithConfiguration(PropertyFetchToMethodCallRector::class, [
+        new PropertyFetchToMethodCall('Cake\Network\Socket', 'connected', 'isConnected'),
+        new PropertyFetchToMethodCall('Cake\Network\Socket', 'encrypted', 'isEncrypted'),
+        new PropertyFetchToMethodCall('Cake\Network\Socket', 'lastError', 'lastError'),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(
+        RemoveIntermediaryMethodRector::class,
+        [new RemoveIntermediaryMethod('getTableLocator', 'get', 'fetchTable')]
+    );
+
+    $rectorConfig->ruleWithConfiguration(MethodCallToAnotherMethodCallWithArgumentsRector::class, [
+        new MethodCallToAnotherMethodCallWithArguments(
+            'Cake\Database\DriverInterface',
+            'supportsQuoting',
+            'supports',
+            ['quote'],
+        ),
+        new MethodCallToAnotherMethodCallWithArguments(
+            'Cake\Database\DriverInterface',
+            'supportsSavepoints',
+            'supports',
+            ['savepoint']
+        ),
+    ]);
+};

--- a/config/sets/cakephp43.php
+++ b/config/sets/cakephp43.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Rector\CakePHP\Rector\MethodCall\RemoveIntermediaryMethodRector;
-
 use Rector\CakePHP\ValueObject\RemoveIntermediaryMethod;
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;

--- a/config/sets/cakephp43.php
+++ b/config/sets/cakephp43.php
@@ -15,7 +15,7 @@ use Rector\Transform\ValueObject\PropertyFetchToMethodCall;
 
 # source: https://book.cakephp.org/4.next/en/appendices/4-3-migration-guide.html
 return static function (RectorConfig $rectorConfig): void {
-
+    $rectorConfig->import(__DIR__ . '/../config.php');
     $rectorConfig->ruleWithConfiguration(
         RenameMethodRector::class,
         [new MethodCallRename('Cake\Controller\Component', 'shutdown', 'afterFilter')]

--- a/config/sets/cakephp44.php
+++ b/config/sets/cakephp44.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+use Rector\Renaming\ValueObject\MethodCallRename;
+
+# @see https://book.cakephp.org/4/en/appendices/4-4-migration-guide.html
+return static function (RectorConfig $rectorConfig): void {
+
+    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
+        'Cake\TestSuite\ConsoleIntegrationTestTrait' => 'Cake\Console\TestSuite\ConsoleIntegrationTestTrait',
+        'Cake\TestSuite\Stub\ConsoleInput' => 'Cake\Console\TestSuite\StubConsoleInput',
+        'Cake\TestSuite\Stub\ConsoleOutput' => 'Cake\Console\TestSuite\StubConsoleOutput',
+        'Cake\TestSuite\Stub\MissingConsoleInputException' => 'Cake\Console\TestSuite\MissingConsoleInputException',
+        'Cake\TestSuite\HttpClientTrait' => 'Cake\Http\TestSuite\HttpClientTrait',
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameMethodRector::class,
+        [new MethodCallRename('Cake\Database\Query', 'newExpr', 'expr')]
+    );
+};

--- a/config/sets/cakephp44.php
+++ b/config/sets/cakephp44.php
@@ -9,7 +9,7 @@ use Rector\Renaming\ValueObject\MethodCallRename;
 
 # @see https://book.cakephp.org/4/en/appendices/4-4-migration-guide.html
 return static function (RectorConfig $rectorConfig): void {
-
+    $rectorConfig->import(__DIR__ . '/../config.php');
     $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
         'Cake\TestSuite\ConsoleIntegrationTestTrait' => 'Cake\Console\TestSuite\ConsoleIntegrationTestTrait',
         'Cake\TestSuite\Stub\ConsoleInput' => 'Cake\Console\TestSuite\StubConsoleInput',

--- a/config/sets/level/up-to-cakephp-34.php
+++ b/config/sets/level/up-to-cakephp-34.php
@@ -6,6 +6,5 @@ use Rector\CakePHP\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../config.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_30, CakePHPSetList::CAKEPHP_34]);
 };

--- a/config/sets/level/up-to-cakephp-34.php
+++ b/config/sets/level/up-to-cakephp-34.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CakePHP\Set\CakePHPSetList;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+
+    $rectorConfig->sets([CakePHPSetList::CAKEPHP_30, CakePHPSetList::CAKEPHP_34]);
+};

--- a/config/sets/level/up-to-cakephp-34.php
+++ b/config/sets/level/up-to-cakephp-34.php
@@ -6,6 +6,6 @@ use Rector\CakePHP\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-
+    $rectorConfig->import(__DIR__ . '/../../config.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_30, CakePHPSetList::CAKEPHP_34]);
 };

--- a/config/sets/level/up-to-cakephp-35.php
+++ b/config/sets/level/up-to-cakephp-35.php
@@ -7,6 +7,5 @@ use Rector\CakePHP\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../config.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_35, CakePHPLevelSetList::UP_TO_CAKEPHP_34]);
 };

--- a/config/sets/level/up-to-cakephp-35.php
+++ b/config/sets/level/up-to-cakephp-35.php
@@ -7,6 +7,6 @@ use Rector\CakePHP\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-
+    $rectorConfig->import(__DIR__ . '/../../config.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_35, CakePHPLevelSetList::UP_TO_CAKEPHP_34]);
 };

--- a/config/sets/level/up-to-cakephp-35.php
+++ b/config/sets/level/up-to-cakephp-35.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CakePHP\Set\CakePHPLevelSetList;
+use Rector\CakePHP\Set\CakePHPSetList;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+
+    $rectorConfig->sets([CakePHPSetList::CAKEPHP_35, CakePHPLevelSetList::UP_TO_CAKEPHP_34]);
+};

--- a/config/sets/level/up-to-cakephp-36.php
+++ b/config/sets/level/up-to-cakephp-36.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CakePHP\Set\CakePHPLevelSetList;
+use Rector\CakePHP\Set\CakePHPSetList;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+
+    $rectorConfig->sets([CakePHPSetList::CAKEPHP_36, CakePHPLevelSetList::UP_TO_CAKEPHP_35]);
+};

--- a/config/sets/level/up-to-cakephp-36.php
+++ b/config/sets/level/up-to-cakephp-36.php
@@ -7,6 +7,6 @@ use Rector\CakePHP\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-
+    $rectorConfig->import(__DIR__ . '/../../config.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_36, CakePHPLevelSetList::UP_TO_CAKEPHP_35]);
 };

--- a/config/sets/level/up-to-cakephp-36.php
+++ b/config/sets/level/up-to-cakephp-36.php
@@ -7,6 +7,5 @@ use Rector\CakePHP\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../config.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_36, CakePHPLevelSetList::UP_TO_CAKEPHP_35]);
 };

--- a/config/sets/level/up-to-cakephp-37.php
+++ b/config/sets/level/up-to-cakephp-37.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CakePHP\Set\CakePHPLevelSetList;
+use Rector\CakePHP\Set\CakePHPSetList;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+
+    $rectorConfig->sets([CakePHPSetList::CAKEPHP_37, CakePHPLevelSetList::UP_TO_CAKEPHP_36]);
+};

--- a/config/sets/level/up-to-cakephp-37.php
+++ b/config/sets/level/up-to-cakephp-37.php
@@ -7,6 +7,6 @@ use Rector\CakePHP\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-
+    $rectorConfig->import(__DIR__ . '/../../config.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_37, CakePHPLevelSetList::UP_TO_CAKEPHP_36]);
 };

--- a/config/sets/level/up-to-cakephp-37.php
+++ b/config/sets/level/up-to-cakephp-37.php
@@ -7,6 +7,5 @@ use Rector\CakePHP\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../config.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_37, CakePHPLevelSetList::UP_TO_CAKEPHP_36]);
 };

--- a/config/sets/level/up-to-cakephp-38.php
+++ b/config/sets/level/up-to-cakephp-38.php
@@ -7,6 +7,5 @@ use Rector\CakePHP\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../config.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_38, CakePHPLevelSetList::UP_TO_CAKEPHP_37]);
 };

--- a/config/sets/level/up-to-cakephp-38.php
+++ b/config/sets/level/up-to-cakephp-38.php
@@ -7,6 +7,6 @@ use Rector\CakePHP\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-
+    $rectorConfig->import(__DIR__ . '/../../config.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_38, CakePHPLevelSetList::UP_TO_CAKEPHP_37]);
 };

--- a/config/sets/level/up-to-cakephp-38.php
+++ b/config/sets/level/up-to-cakephp-38.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CakePHP\Set\CakePHPLevelSetList;
+use Rector\CakePHP\Set\CakePHPSetList;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+
+    $rectorConfig->sets([CakePHPSetList::CAKEPHP_38, CakePHPLevelSetList::UP_TO_CAKEPHP_37]);
+};

--- a/config/sets/level/up-to-cakephp-40.php
+++ b/config/sets/level/up-to-cakephp-40.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CakePHP\Set\CakePHPLevelSetList;
+use Rector\CakePHP\Set\CakePHPSetList;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+
+    $rectorConfig->sets([CakePHPSetList::CAKEPHP_40, CakePHPLevelSetList::UP_TO_CAKEPHP_38]);
+};

--- a/config/sets/level/up-to-cakephp-40.php
+++ b/config/sets/level/up-to-cakephp-40.php
@@ -7,6 +7,5 @@ use Rector\CakePHP\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../config.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_40, CakePHPLevelSetList::UP_TO_CAKEPHP_38]);
 };

--- a/config/sets/level/up-to-cakephp-40.php
+++ b/config/sets/level/up-to-cakephp-40.php
@@ -7,6 +7,6 @@ use Rector\CakePHP\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-
+    $rectorConfig->import(__DIR__ . '/../../config.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_40, CakePHPLevelSetList::UP_TO_CAKEPHP_38]);
 };

--- a/config/sets/level/up-to-cakephp-41.php
+++ b/config/sets/level/up-to-cakephp-41.php
@@ -7,6 +7,6 @@ use Rector\CakePHP\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-
+    $rectorConfig->import(__DIR__ . '/../../config.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_41, CakePHPLevelSetList::UP_TO_CAKEPHP_40]);
 };

--- a/config/sets/level/up-to-cakephp-41.php
+++ b/config/sets/level/up-to-cakephp-41.php
@@ -7,6 +7,5 @@ use Rector\CakePHP\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../config.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_41, CakePHPLevelSetList::UP_TO_CAKEPHP_40]);
 };

--- a/config/sets/level/up-to-cakephp-41.php
+++ b/config/sets/level/up-to-cakephp-41.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CakePHP\Set\CakePHPLevelSetList;
+use Rector\CakePHP\Set\CakePHPSetList;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+
+    $rectorConfig->sets([CakePHPSetList::CAKEPHP_41, CakePHPLevelSetList::UP_TO_CAKEPHP_40]);
+};

--- a/config/sets/level/up-to-cakephp-42.php
+++ b/config/sets/level/up-to-cakephp-42.php
@@ -7,6 +7,5 @@ use Rector\CakePHP\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../config.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_42, CakePHPLevelSetList::UP_TO_CAKEPHP_41]);
 };

--- a/config/sets/level/up-to-cakephp-42.php
+++ b/config/sets/level/up-to-cakephp-42.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CakePHP\Set\CakePHPLevelSetList;
+use Rector\CakePHP\Set\CakePHPSetList;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+
+    $rectorConfig->sets([CakePHPSetList::CAKEPHP_42, CakePHPLevelSetList::UP_TO_CAKEPHP_41]);
+};

--- a/config/sets/level/up-to-cakephp-42.php
+++ b/config/sets/level/up-to-cakephp-42.php
@@ -7,6 +7,6 @@ use Rector\CakePHP\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-
+    $rectorConfig->import(__DIR__ . '/../../config.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_42, CakePHPLevelSetList::UP_TO_CAKEPHP_41]);
 };

--- a/config/sets/level/up-to-cakephp-43.php
+++ b/config/sets/level/up-to-cakephp-43.php
@@ -7,6 +7,5 @@ use Rector\CakePHP\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../config.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_43, CakePHPLevelSetList::UP_TO_CAKEPHP_42]);
 };

--- a/config/sets/level/up-to-cakephp-43.php
+++ b/config/sets/level/up-to-cakephp-43.php
@@ -7,6 +7,6 @@ use Rector\CakePHP\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-
+    $rectorConfig->import(__DIR__ . '/../../config.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_43, CakePHPLevelSetList::UP_TO_CAKEPHP_42]);
 };

--- a/config/sets/level/up-to-cakephp-43.php
+++ b/config/sets/level/up-to-cakephp-43.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CakePHP\Set\CakePHPLevelSetList;
+use Rector\CakePHP\Set\CakePHPSetList;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+
+    $rectorConfig->sets([CakePHPSetList::CAKEPHP_43, CakePHPLevelSetList::UP_TO_CAKEPHP_42]);
+};

--- a/config/sets/level/up-to-cakephp-44.php
+++ b/config/sets/level/up-to-cakephp-44.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CakePHP\Set\CakePHPLevelSetList;
+use Rector\CakePHP\Set\CakePHPSetList;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+
+    $rectorConfig->sets([CakePHPSetList::CAKEPHP_44, CakePHPLevelSetList::UP_TO_CAKEPHP_43]);
+};

--- a/config/sets/level/up-to-cakephp-44.php
+++ b/config/sets/level/up-to-cakephp-44.php
@@ -7,6 +7,5 @@ use Rector\CakePHP\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../config.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_44, CakePHPLevelSetList::UP_TO_CAKEPHP_43]);
 };

--- a/config/sets/level/up-to-cakephp-44.php
+++ b/config/sets/level/up-to-cakephp-44.php
@@ -7,6 +7,6 @@ use Rector\CakePHP\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-
+    $rectorConfig->import(__DIR__ . '/../../config.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_44, CakePHPLevelSetList::UP_TO_CAKEPHP_43]);
 };

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -5,4 +5,5 @@
     <rule ref="CakePHP" />
 
     <exclude-pattern>tests/test_apps</exclude-pattern>
+    <exclude-pattern>src/RectorCakePHP</exclude-pattern>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,4 +6,5 @@
 
     <exclude-pattern>tests/test_apps</exclude-pattern>
     <exclude-pattern>src/RectorCakePHP</exclude-pattern>
+    <exclude-pattern>tests/Rector</exclude-pattern>
 </ruleset>

--- a/src/Command/RectorCommand.php
+++ b/src/Command/RectorCommand.php
@@ -83,7 +83,7 @@ class RectorCommand extends BaseCommand
 
         $cmdPath = ROOT . '/vendor/bin/rector process';
         $command = sprintf(
-            '%s %s --autoload-file=%s --config=%s %s --clear-cache',
+            '%s %s --autoload-file=%s --config=%s %s',
             $cmdPath,
             $args->getOption('dry-run') ? '--dry-run' : '',
             escapeshellarg($autoload),

--- a/src/Command/RectorCommand.php
+++ b/src/Command/RectorCommand.php
@@ -83,7 +83,7 @@ class RectorCommand extends BaseCommand
 
         $cmdPath = ROOT . '/vendor/bin/rector process';
         $command = sprintf(
-            '%s %s --autoload-file=%s --config=%s %s',
+            '%s %s --autoload-file=%s --config=%s %s --clear-cache',
             $cmdPath,
             $args->getOption('dry-run') ? '--dry-run' : '',
             escapeshellarg($autoload),

--- a/src/RectorCakePHP/ImplicitNameResolver.php
+++ b/src/RectorCakePHP/ImplicitNameResolver.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CakePHP;
+
+/**
+ * @inspired https://github.com/cakephp/upgrade/blob/756410c8b7d5aff9daec3fa1fe750a3858d422ac/src/Shell/Task/AppUsesTask.php
+ */
+final class ImplicitNameResolver
+{
+    /**
+     * A map of old => new for use statements that are missing
+     *
+     * @var string[]
+     */
+    private const IMPLICIT_MAP = [
+        'App' => 'Cake\Core\App',
+        'AppController' => 'App\Controller\AppController',
+        'AppHelper' => 'App\View\Helper\AppHelper',
+        'AppModel' => 'App\Model\AppModel',
+        'Cache' => 'Cake\Cache\Cache',
+        'CakeEventListener' => 'Cake\Event\EventListener',
+        'CakeLog' => 'Cake\Log\Log',
+        'CakePlugin' => 'Cake\Core\Plugin',
+        'CakeTestCase' => 'Cake\TestSuite\TestCase',
+        'CakeTestFixture' => 'Cake\TestSuite\Fixture\TestFixture',
+        'Component' => 'Cake\Controller\Component',
+        'ComponentRegistry' => 'Cake\Controller\ComponentRegistry',
+        'Configure' => 'Cake\Core\Configure',
+        'ConnectionManager' => 'Cake\Database\ConnectionManager',
+        'Controller' => 'Cake\Controller\Controller',
+        'Debugger' => 'Cake\Error\Debugger',
+        'ExceptionRenderer' => 'Cake\Error\ExceptionRenderer',
+        'Helper' => 'Cake\View\Helper',
+        'HelperRegistry' => 'Cake\View\HelperRegistry',
+        'Inflector' => 'Cake\Utility\Inflector',
+        'Model' => 'Cake\Model\Model',
+        'ModelBehavior' => 'Cake\Model\Behavior',
+        'Object' => 'Cake\Core\Object',
+        'Router' => 'Cake\Routing\Router',
+        'Shell' => 'Cake\Console\Shell',
+        'View' => 'Cake\View\View',
+        // Also apply to already renamed ones
+        'Log' => 'Cake\Log\Log',
+        'Plugin' => 'Cake\Core\Plugin',
+        'TestCase' => 'Cake\TestSuite\TestCase',
+        'TestFixture' => 'Cake\TestSuite\Fixture\TestFixture',
+    ];
+
+    /**
+     * This value used to be directory So "/" in path should be "\" in namespace
+     */
+    public function resolve(string $shortClass): ?string
+    {
+        return self::IMPLICIT_MAP[$shortClass] ?? null;
+    }
+}

--- a/src/RectorCakePHP/ImplicitNameResolver.php
+++ b/src/RectorCakePHP/ImplicitNameResolver.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Rector\CakePHP;

--- a/src/RectorCakePHP/Naming/CakePHPFullyQualifiedClassNameResolver.php
+++ b/src/RectorCakePHP/Naming/CakePHPFullyQualifiedClassNameResolver.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Rector\CakePHP\Naming;
@@ -65,10 +64,12 @@ final class CakePHPFullyQualifiedClassNameResolver
         }
 
         // C. is not plugin nor lib custom App class?
-        if (\str_contains($pseudoNamespace, '\\') && ! StringUtils::isMatch(
-            $pseudoNamespace,
-            self::PLUGIN_OR_LIB_REGEX
-        )) {
+        if (
+            \str_contains($pseudoNamespace, '\\') && ! StringUtils::isMatch(
+                $pseudoNamespace,
+                self::PLUGIN_OR_LIB_REGEX
+            )
+        ) {
             return 'App\\' . $pseudoNamespace . '\\' . $shortClass;
         }
 

--- a/src/RectorCakePHP/Naming/CakePHPFullyQualifiedClassNameResolver.php
+++ b/src/RectorCakePHP/Naming/CakePHPFullyQualifiedClassNameResolver.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CakePHP\Naming;
+
+use Nette\Utils\Strings;
+use PHPStan\Reflection\ReflectionProvider;
+use Rector\CakePHP\ImplicitNameResolver;
+use Rector\Core\Util\StringUtils;
+
+/**
+ * @inspired https://github.com/cakephp/upgrade/blob/756410c8b7d5aff9daec3fa1fe750a3858d422ac/src/Shell/Task/AppUsesTask.php
+ */
+final class CakePHPFullyQualifiedClassNameResolver
+{
+    /**
+     * @var string
+     * @see https://regex101.com/r/mbvKJp/1
+     */
+    final public const LIB_NAMESPACE_PART_REGEX = '#\\\\Lib\\\\#';
+
+    /**
+     * @var string
+     * @see https://regex101.com/r/XvoZIP/1
+     */
+    private const SLASH_REGEX = '#(/|\.)#';
+
+    /**
+     * @var string
+     * @see https://regex101.com/r/lq0lQ9/1
+     */
+    private const PLUGIN_OR_LIB_REGEX = '#(Plugin|Lib)#';
+
+    public function __construct(
+        private readonly ImplicitNameResolver $implicitNameResolver,
+        private readonly ReflectionProvider $reflectionProvider
+    ) {
+    }
+
+    /**
+     * This value used to be directory So "/" in path should be "\" in namespace
+     */
+    public function resolveFromPseudoNamespaceAndShortClassName(string $pseudoNamespace, string $shortClass): string
+    {
+        $pseudoNamespace = $this->normalizeFileSystemSlashes($pseudoNamespace);
+
+        $resolvedShortClass = $this->implicitNameResolver->resolve($shortClass);
+
+        // A. is known renamed class?
+        if ($resolvedShortClass !== null) {
+            return $resolvedShortClass;
+        }
+
+        // Chop Lib out as locations moves those files to the top level.
+        // But only if Lib is not the last folder.
+        if (StringUtils::isMatch($pseudoNamespace, self::LIB_NAMESPACE_PART_REGEX)) {
+            $pseudoNamespace = Strings::replace($pseudoNamespace, '#\\\\Lib#', '');
+        }
+
+        // B. is Cake native class?
+        $cakePhpVersion = 'Cake\\' . $pseudoNamespace . '\\' . $shortClass;
+        if ($this->reflectionProvider->hasClass($cakePhpVersion)) {
+            return $cakePhpVersion;
+        }
+
+        // C. is not plugin nor lib custom App class?
+        if (\str_contains($pseudoNamespace, '\\') && ! StringUtils::isMatch(
+            $pseudoNamespace,
+            self::PLUGIN_OR_LIB_REGEX
+        )) {
+            return 'App\\' . $pseudoNamespace . '\\' . $shortClass;
+        }
+
+        return $pseudoNamespace . '\\' . $shortClass;
+    }
+
+    private function normalizeFileSystemSlashes(string $pseudoNamespace): string
+    {
+        return Strings::replace($pseudoNamespace, self::SLASH_REGEX, '\\');
+    }
+}

--- a/src/RectorCakePHP/Naming/CakePHPFullyQualifiedClassNameResolver.php
+++ b/src/RectorCakePHP/Naming/CakePHPFullyQualifiedClassNameResolver.php
@@ -17,7 +17,7 @@ final class CakePHPFullyQualifiedClassNameResolver
      * @var string
      * @see https://regex101.com/r/mbvKJp/1
      */
-    final public const LIB_NAMESPACE_PART_REGEX = '#\\\\Lib\\\\#';
+    public const LIB_NAMESPACE_PART_REGEX = '#\\\\Lib\\\\#';
 
     /**
      * @var string
@@ -32,8 +32,8 @@ final class CakePHPFullyQualifiedClassNameResolver
     private const PLUGIN_OR_LIB_REGEX = '#(Plugin|Lib)#';
 
     public function __construct(
-        private readonly ImplicitNameResolver $implicitNameResolver,
-        private readonly ReflectionProvider $reflectionProvider
+        private ImplicitNameResolver $implicitNameResolver,
+        private ReflectionProvider $reflectionProvider
     ) {
     }
 

--- a/src/RectorCakePHP/Rector/MethodCall/ArrayToFluentCallRector.php
+++ b/src/RectorCakePHP/Rector/MethodCall/ArrayToFluentCallRector.php
@@ -24,12 +24,12 @@ final class ArrayToFluentCallRector extends AbstractRector implements Configurab
     /**
      * @var string
      */
-    final public const ARRAYS_TO_FLUENT_CALLS = 'arrays_to_fluent_calls';
+    public const ARRAYS_TO_FLUENT_CALLS = 'arrays_to_fluent_calls';
 
     /**
      * @var string
      */
-    final public const FACTORY_METHODS = 'factory_methods';
+    public const FACTORY_METHODS = 'factory_methods';
 
     /**
      * @var \Rector\CakePHP\ValueObject\ArrayToFluentCall[]

--- a/src/RectorCakePHP/Rector/MethodCall/ArrayToFluentCallRector.php
+++ b/src/RectorCakePHP/Rector/MethodCall/ArrayToFluentCallRector.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CakePHP\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Scalar\String_;
+use Rector\CakePHP\ValueObject\ArrayItemsAndFluentClass;
+use Rector\CakePHP\ValueObject\ArrayToFluentCall;
+use Rector\CakePHP\ValueObject\FactoryMethod;
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+/**
+ * @see \Rector\CakePHP\Tests\Rector\MethodCall\ArrayToFluentCallRector\ArrayToFluentCallRectorTest
+ */
+final class ArrayToFluentCallRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    /**
+     * @var string
+     */
+    final public const ARRAYS_TO_FLUENT_CALLS = 'arrays_to_fluent_calls';
+
+    /**
+     * @var string
+     */
+    final public const FACTORY_METHODS = 'factory_methods';
+
+    /**
+     * @var ArrayToFluentCall[]
+     */
+    private array $arraysToFluentCalls = [];
+
+    /**
+     * @var FactoryMethod[]
+     */
+    private array $factoryMethods = [];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Moves array options to fluent setter method calls.', [
+            new ConfiguredCodeSample(
+                <<<'CODE_SAMPLE'
+use Cake\ORM\Table;
+
+final class ArticlesTable extends Table
+{
+    public function initialize(array $config)
+    {
+        $this->belongsTo('Authors', [
+            'foreignKey' => 'author_id',
+            'propertyName' => 'person'
+        ]);
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+use Cake\ORM\Table;
+
+final class ArticlesTable extends Table
+{
+    public function initialize(array $config)
+    {
+        $this->belongsTo('Authors')
+            ->setForeignKey('author_id')
+            ->setProperty('person');
+    }
+}
+CODE_SAMPLE
+                ,
+                [
+                    self::ARRAYS_TO_FLUENT_CALLS => [
+                        new ArrayToFluentCall('ArticlesTable', [
+                            'foreignKey' => 'setForeignKey',
+                            'propertyName' => 'setProperty',
+                        ]),
+                    ],
+                ]
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param MethodCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $factoryMethod = $this->matchTypeAndMethodName($node);
+        if (! $factoryMethod instanceof FactoryMethod) {
+            return null;
+        }
+
+        foreach ($this->arraysToFluentCalls as $arrayToFluentCall) {
+            if ($arrayToFluentCall->getClass() !== $factoryMethod->getNewClass()) {
+                continue;
+            }
+
+            return $this->replaceArrayToFluentMethodCalls($node, $factoryMethod->getPosition(), $arrayToFluentCall);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param mixed[] $configuration
+     */
+    public function configure(array $configuration): void
+    {
+        $arraysToFluentCalls = $configuration[self::ARRAYS_TO_FLUENT_CALLS] ?? [];
+        Assert::isArray($arraysToFluentCalls);
+        Assert::allIsInstanceOf($arraysToFluentCalls, ArrayToFluentCall::class);
+
+        $this->arraysToFluentCalls = $arraysToFluentCalls;
+
+        $factoryMethods = $configuration[self::FACTORY_METHODS] ?? [];
+        Assert::isArray($factoryMethods);
+        Assert::allIsInstanceOf($factoryMethods, FactoryMethod::class);
+        $this->factoryMethods = $factoryMethods;
+    }
+
+    private function matchTypeAndMethodName(MethodCall $methodCall): ?FactoryMethod
+    {
+        foreach ($this->factoryMethods as $factoryMethod) {
+            if (! $this->isObjectType($methodCall->var, $factoryMethod->getObjectType())) {
+                continue;
+            }
+
+            if (! $this->isName($methodCall->name, $factoryMethod->getMethod())) {
+                continue;
+            }
+
+            return $factoryMethod;
+        }
+
+        return null;
+    }
+
+    private function replaceArrayToFluentMethodCalls(
+        MethodCall $methodCall,
+        int $argumentPosition,
+        ArrayToFluentCall $arrayToFluentCall
+    ): ?MethodCall {
+        if (count($methodCall->args) !== $argumentPosition) {
+            return null;
+        }
+
+        $argumentValue = $methodCall->args[$argumentPosition - 1]->value;
+        if (! $argumentValue instanceof Array_) {
+            return null;
+        }
+
+        $arrayItemsAndFluentClass = $this->extractFluentMethods(
+            $argumentValue->items,
+            $arrayToFluentCall->getArrayKeysToFluentCalls()
+        );
+
+        if ($arrayItemsAndFluentClass->getArrayItems() !== []) {
+            $argumentValue->items = $arrayItemsAndFluentClass->getArrayItems();
+        } else {
+            $positionToRemove = $argumentPosition - 1;
+            $this->nodeRemover->removeArg($methodCall, $positionToRemove);
+        }
+
+        if ($arrayItemsAndFluentClass->getFluentCalls() === []) {
+            return null;
+        }
+
+        $node = $methodCall;
+
+        foreach ($arrayItemsAndFluentClass->getFluentCalls() as $method => $expr) {
+            $args = $this->nodeFactory->createArgs([$expr]);
+            $node = $this->nodeFactory->createMethodCall($node, $method, $args);
+        }
+
+        return $node;
+    }
+
+    /**
+     * @param array<ArrayItem|null> $originalArrayItems
+     * @param array<string, string> $arrayMap
+     */
+    private function extractFluentMethods(array $originalArrayItems, array $arrayMap): ArrayItemsAndFluentClass
+    {
+        $newArrayItems = [];
+        $fluentCalls = [];
+
+        foreach ($originalArrayItems as $originalArrayItem) {
+            if ($originalArrayItem === null) {
+                continue;
+            }
+
+            $key = $originalArrayItem->key;
+
+            if ($key instanceof String_ && isset($arrayMap[$key->value])) {
+                /** @var string $methodName */
+                $methodName = $arrayMap[$key->value];
+                $fluentCalls[$methodName] = $originalArrayItem->value;
+            } else {
+                $newArrayItems[] = $originalArrayItem;
+            }
+        }
+
+        return new ArrayItemsAndFluentClass($newArrayItems, $fluentCalls);
+    }
+}

--- a/src/RectorCakePHP/Rector/MethodCall/ArrayToFluentCallRector.php
+++ b/src/RectorCakePHP/Rector/MethodCall/ArrayToFluentCallRector.php
@@ -1,12 +1,10 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Rector\CakePHP\Rector\MethodCall;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;
-use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Scalar\String_;
 use Rector\CakePHP\ValueObject\ArrayItemsAndFluentClass;
@@ -34,12 +32,12 @@ final class ArrayToFluentCallRector extends AbstractRector implements Configurab
     final public const FACTORY_METHODS = 'factory_methods';
 
     /**
-     * @var ArrayToFluentCall[]
+     * @var \Rector\CakePHP\ValueObject\ArrayToFluentCall[]
      */
     private array $arraysToFluentCalls = [];
 
     /**
-     * @var FactoryMethod[]
+     * @var \Rector\CakePHP\ValueObject\FactoryMethod[]
      */
     private array $factoryMethods = [];
 
@@ -89,7 +87,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @return array<class-string<Node>>
+     * @return array<class-string<\PhpParser\Node>>
      */
     public function getNodeTypes(): array
     {
@@ -97,7 +95,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param MethodCall $node
+     * @param \PhpParser\Node\Expr\MethodCall $node
      */
     public function refactor(Node $node): ?Node
     {
@@ -192,7 +190,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param array<ArrayItem|null> $originalArrayItems
+     * @param array<(\PhpParser\Node\Expr\ArrayItem|null)> $originalArrayItems
      * @param array<string, string> $arrayMap
      */
     private function extractFluentMethods(array $originalArrayItems, array $arrayMap): ArrayItemsAndFluentClass

--- a/src/RectorCakePHP/Rector/MethodCall/ModalToGetSetRector.php
+++ b/src/RectorCakePHP/Rector/MethodCall/ModalToGetSetRector.php
@@ -25,7 +25,7 @@ final class ModalToGetSetRector extends AbstractRector implements ConfigurableRe
     /**
      * @var string
      */
-    final public const UNPREFIXED_METHODS_TO_GET_SET = 'unprefixed_methods_to_get_set';
+    public const UNPREFIXED_METHODS_TO_GET_SET = 'unprefixed_methods_to_get_set';
 
     /**
      * @var \Rector\CakePHP\ValueObject\ModalToGetSet[]

--- a/src/RectorCakePHP/Rector/MethodCall/ModalToGetSetRector.php
+++ b/src/RectorCakePHP/Rector/MethodCall/ModalToGetSetRector.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Rector\CakePHP\Rector\MethodCall;
@@ -29,7 +28,7 @@ final class ModalToGetSetRector extends AbstractRector implements ConfigurableRe
     final public const UNPREFIXED_METHODS_TO_GET_SET = 'unprefixed_methods_to_get_set';
 
     /**
-     * @var ModalToGetSet[]
+     * @var \Rector\CakePHP\ValueObject\ModalToGetSet[]
      */
     private array $unprefixedMethodsToGetSet = [];
 
@@ -70,7 +69,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @return array<class-string<Node>>
+     * @return array<class-string<\PhpParser\Node>>
      */
     public function getNodeTypes(): array
     {
@@ -78,7 +77,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param MethodCall $node
+     * @param \PhpParser\Node\Expr\MethodCall $node
      */
     public function refactor(Node $node): ?Node
     {

--- a/src/RectorCakePHP/Rector/MethodCall/ModalToGetSetRector.php
+++ b/src/RectorCakePHP/Rector/MethodCall/ModalToGetSetRector.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CakePHP\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use Rector\CakePHP\ValueObject\ModalToGetSet;
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+/**
+ * @see https://book.cakephp.org/3.0/en/appendices/3-4-migration-guide.html#deprecated-combined-get-set-methods
+ * @see https://github.com/cakephp/cakephp/commit/326292688c5e6d08945a3cafa4b6ffb33e714eea#diff-e7c0f0d636ca50a0350e9be316d8b0f9
+ *
+ * @see \Rector\CakePHP\Tests\Rector\MethodCall\ModalToGetSetRector\ModalToGetSetRectorTest
+ */
+final class ModalToGetSetRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    /**
+     * @var string
+     */
+    final public const UNPREFIXED_METHODS_TO_GET_SET = 'unprefixed_methods_to_get_set';
+
+    /**
+     * @var ModalToGetSet[]
+     */
+    private array $unprefixedMethodsToGetSet = [];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Changes combined set/get `value()` to specific `getValue()` or `setValue(x)`.',
+            [
+                new ConfiguredCodeSample(
+                    <<<'CODE_SAMPLE'
+$object = new InstanceConfigTrait;
+
+$config = $object->config();
+$config = $object->config('key');
+
+$object->config('key', 'value');
+$object->config(['key' => 'value']);
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+$object = new InstanceConfigTrait;
+
+$config = $object->getConfig();
+$config = $object->getConfig('key');
+
+$object->setConfig('key', 'value');
+$object->setConfig(['key' => 'value']);
+CODE_SAMPLE
+                    ,
+                    [
+                        self::UNPREFIXED_METHODS_TO_GET_SET => [
+                            new ModalToGetSet('InstanceConfigTrait', 'config', 'getConfig', 'setConfig'),
+                        ],
+                    ]
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param MethodCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $modalToGetSet = $this->matchTypeAndMethodName($node);
+        if (! $modalToGetSet instanceof ModalToGetSet) {
+            return null;
+        }
+
+        $newName = $this->resolveNewMethodNameByCondition($node, $modalToGetSet);
+        $node->name = new Identifier($newName);
+
+        return $node;
+    }
+
+    /**
+     * @param mixed[] $configuration
+     */
+    public function configure(array $configuration): void
+    {
+        $unprefixedMethodsToGetSet = $configuration[self::UNPREFIXED_METHODS_TO_GET_SET] ?? $configuration;
+        Assert::isArray($unprefixedMethodsToGetSet);
+        Assert::allIsAOf($unprefixedMethodsToGetSet, ModalToGetSet::class);
+
+        $this->unprefixedMethodsToGetSet = $unprefixedMethodsToGetSet;
+    }
+
+    private function matchTypeAndMethodName(MethodCall $methodCall): ?ModalToGetSet
+    {
+        foreach ($this->unprefixedMethodsToGetSet as $unprefixedMethodToGetSet) {
+            if (! $this->isObjectType($methodCall->var, $unprefixedMethodToGetSet->getObjectType())) {
+                continue;
+            }
+
+            if (! $this->isName($methodCall->name, $unprefixedMethodToGetSet->getUnprefixedMethod())) {
+                continue;
+            }
+
+            return $unprefixedMethodToGetSet;
+        }
+
+        return null;
+    }
+
+    private function resolveNewMethodNameByCondition(
+        MethodCall $methodCall,
+        ModalToGetSet $modalToGetSet
+    ): string {
+        if (count($methodCall->args) >= $modalToGetSet->getMinimalSetterArgumentCount()) {
+            return $modalToGetSet->getSetMethod();
+        }
+
+        if (! isset($methodCall->args[0])) {
+            return $modalToGetSet->getGetMethod();
+        }
+
+        // first argument type that is considered setter
+        if ($modalToGetSet->getFirstArgumentType() === null) {
+            return $modalToGetSet->getGetMethod();
+        }
+
+        $firstArgumentType = $modalToGetSet->getFirstArgumentType();
+        $argumentValue = $methodCall->args[0]->value;
+
+        if ($firstArgumentType === 'array' && $argumentValue instanceof Array_) {
+            return $modalToGetSet->getSetMethod();
+        }
+
+        return $modalToGetSet->getGetMethod();
+    }
+}

--- a/src/RectorCakePHP/Rector/MethodCall/RemoveIntermediaryMethodRector.php
+++ b/src/RectorCakePHP/Rector/MethodCall/RemoveIntermediaryMethodRector.php
@@ -26,7 +26,7 @@ final class RemoveIntermediaryMethodRector extends AbstractRector implements Con
     /**
      * @var string
      */
-    final public const REMOVE_INTERMEDIARY_METHOD = 'remove_intermediary_method';
+    public const REMOVE_INTERMEDIARY_METHOD = 'remove_intermediary_method';
 
     /**
      * @var \Rector\CakePHP\ValueObject\RemoveIntermediaryMethod[]
@@ -34,7 +34,7 @@ final class RemoveIntermediaryMethodRector extends AbstractRector implements Con
     private array $removeIntermediaryMethod = [];
 
     public function __construct(
-        private readonly FluentChainMethodCallNodeAnalyzer $fluentChainMethodCallNodeAnalyzer
+        private FluentChainMethodCallNodeAnalyzer $fluentChainMethodCallNodeAnalyzer
     ) {
     }
 

--- a/src/RectorCakePHP/Rector/MethodCall/RemoveIntermediaryMethodRector.php
+++ b/src/RectorCakePHP/Rector/MethodCall/RemoveIntermediaryMethodRector.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CakePHP\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use Rector\CakePHP\ValueObject\RemoveIntermediaryMethod;
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Defluent\NodeAnalyzer\FluentChainMethodCallNodeAnalyzer;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+/**
+ * @see https://book.cakephp.org/3.0/en/appendices/3-4-migration-guide.html#deprecated-combined-get-set-methods
+ * @see https://github.com/cakephp/cakephp/commit/326292688c5e6d08945a3cafa4b6ffb33e714eea#diff-e7c0f0d636ca50a0350e9be316d8b0f9
+ *
+ * @see \Rector\CakePHP\Tests\Rector\MethodCall\ModalToGetSetRector\ModalToGetSetRectorTest
+ */
+final class RemoveIntermediaryMethodRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    /**
+     * @var string
+     */
+    final public const REMOVE_INTERMEDIARY_METHOD = 'remove_intermediary_method';
+
+    /**
+     * @var RemoveIntermediaryMethod[]
+     */
+    private array $removeIntermediaryMethod = [];
+
+    public function __construct(
+        private readonly FluentChainMethodCallNodeAnalyzer $fluentChainMethodCallNodeAnalyzer
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Removes an intermediary method call for when a higher level API is added.',
+            [
+                new ConfiguredCodeSample(
+                    <<<'CODE_SAMPLE'
+$users = $this->getTableLocator()->get('Users');
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+$users = $this->fetchTable('Users');
+CODE_SAMPLE
+                    ,
+                    [
+                        self::REMOVE_INTERMEDIARY_METHOD => [
+                            new RemoveIntermediaryMethod('getTableLocator', 'get', 'fetchTable'),
+                        ],
+                    ]
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param MethodCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $removeIntermediaryMethod = $this->matchTypeAndMethodName($node);
+        if (! $removeIntermediaryMethod instanceof RemoveIntermediaryMethod) {
+            return null;
+        }
+        /** @var MethodCall $var */
+        $var = $node->var;
+        $target = $var->var;
+
+        return new MethodCall($target, $removeIntermediaryMethod->getFinalMethod(), $node->args);
+    }
+
+    /**
+     * @param mixed[] $configuration
+     */
+    public function configure(array $configuration): void
+    {
+        $removeIntermediaryMethods = $configuration[self::REMOVE_INTERMEDIARY_METHOD] ?? $configuration;
+
+        Assert::isArray($removeIntermediaryMethods);
+        Assert::allIsAOf($removeIntermediaryMethods, RemoveIntermediaryMethod::class);
+
+        $this->removeIntermediaryMethod = $removeIntermediaryMethods;
+    }
+
+    private function matchTypeAndMethodName(MethodCall $methodCall): ?RemoveIntermediaryMethod
+    {
+        $rootMethodCall = $this->fluentChainMethodCallNodeAnalyzer->resolveRootMethodCall($methodCall);
+        if (! $rootMethodCall instanceof MethodCall) {
+            return null;
+        }
+        if (! $rootMethodCall->var instanceof Variable) {
+            return null;
+        }
+        if (! $this->nodeNameResolver->isName($rootMethodCall->var, 'this')) {
+            return null;
+        }
+        /** @var MethodCall $var */
+        $var = $methodCall->var;
+        if (
+            (! $methodCall->name instanceof Identifier) ||
+            (! $var->name instanceof Identifier)
+        ) {
+            return null;
+        }
+
+        foreach ($this->removeIntermediaryMethod as $singleRemoveIntermediaryMethod) {
+            if (! $this->isName($methodCall->name, $singleRemoveIntermediaryMethod->getSecondMethod())) {
+                continue;
+            }
+            if (! $this->isName($var->name, $singleRemoveIntermediaryMethod->getFirstMethod())) {
+                continue;
+            }
+
+            return $singleRemoveIntermediaryMethod;
+        }
+
+        return null;
+    }
+}

--- a/src/RectorCakePHP/Rector/MethodCall/RemoveIntermediaryMethodRector.php
+++ b/src/RectorCakePHP/Rector/MethodCall/RemoveIntermediaryMethodRector.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Rector\CakePHP\Rector\MethodCall;
@@ -30,7 +29,7 @@ final class RemoveIntermediaryMethodRector extends AbstractRector implements Con
     final public const REMOVE_INTERMEDIARY_METHOD = 'remove_intermediary_method';
 
     /**
-     * @var RemoveIntermediaryMethod[]
+     * @var \Rector\CakePHP\ValueObject\RemoveIntermediaryMethod[]
      */
     private array $removeIntermediaryMethod = [];
 
@@ -64,7 +63,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @return array<class-string<Node>>
+     * @return array<class-string<\PhpParser\Node>>
      */
     public function getNodeTypes(): array
     {
@@ -72,7 +71,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param MethodCall $node
+     * @param \PhpParser\Node\Expr\MethodCall $node
      */
     public function refactor(Node $node): ?Node
     {
@@ -80,7 +79,7 @@ CODE_SAMPLE
         if (! $removeIntermediaryMethod instanceof RemoveIntermediaryMethod) {
             return null;
         }
-        /** @var MethodCall $var */
+        /** @var \PhpParser\Node\Expr\MethodCall $var */
         $var = $node->var;
         $target = $var->var;
 
@@ -112,7 +111,7 @@ CODE_SAMPLE
         if (! $this->nodeNameResolver->isName($rootMethodCall->var, 'this')) {
             return null;
         }
-        /** @var MethodCall $var */
+        /** @var \PhpParser\Node\Expr\MethodCall $var */
         $var = $methodCall->var;
         if (
             (! $methodCall->name instanceof Identifier) ||

--- a/src/RectorCakePHP/Rector/MethodCall/RenameMethodCallBasedOnParameterRector.php
+++ b/src/RectorCakePHP/Rector/MethodCall/RenameMethodCallBasedOnParameterRector.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CakePHP\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use Rector\CakePHP\ValueObject\RenameMethodCallBasedOnParameter;
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+/**
+ * @see https://book.cakephp.org/4.0/en/appendices/4-0-migration-guide.html
+ * @see https://github.com/cakephp/cakephp/commit/77017145961bb697b4256040b947029259f66a9b
+ *
+ * @see \Rector\CakePHP\Tests\Rector\MethodCall\RenameMethodCallBasedOnParameterRector\RenameMethodCallBasedOnParameterRectorTest
+ */
+final class RenameMethodCallBasedOnParameterRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    /**
+     * @var string
+     */
+    final public const CALLS_WITH_PARAM_RENAMES = 'calls_with_param_renames';
+
+    /**
+     * @var RenameMethodCallBasedOnParameter[]
+     */
+    private array $callsWithParamRenames = [];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        $configuration = [
+            self::CALLS_WITH_PARAM_RENAMES => [
+                new RenameMethodCallBasedOnParameter('ServerRequest', 'getParam', 'paging', 'getAttribute'),
+                new RenameMethodCallBasedOnParameter('ServerRequest', 'withParam', 'paging', 'withAttribute'),
+            ],
+        ];
+        return new RuleDefinition(
+            'Changes method calls based on matching the first parameter value.',
+            [
+                new ConfiguredCodeSample(
+                    <<<'CODE_SAMPLE'
+$object = new ServerRequest();
+
+$config = $object->getParam('paging');
+$object = $object->withParam('paging', ['a value']);
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+$object = new ServerRequest();
+
+$config = $object->getAttribute('paging');
+$object = $object->withAttribute('paging', ['a value']);
+CODE_SAMPLE
+                    ,
+                    $configuration
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param MethodCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $renameMethodCallBasedOnParameter = $this->matchTypeAndMethodName($node);
+        if (! $renameMethodCallBasedOnParameter instanceof RenameMethodCallBasedOnParameter) {
+            return null;
+        }
+
+        $node->name = new Identifier($renameMethodCallBasedOnParameter->getNewMethod());
+
+        return $node;
+    }
+
+    /**
+     * @param mixed[] $configuration
+     */
+    public function configure(array $configuration): void
+    {
+        $callsWithParamRenames = $configuration[self::CALLS_WITH_PARAM_RENAMES] ?? $configuration;
+
+        Assert::isArray($callsWithParamRenames);
+        Assert::allIsInstanceOf($callsWithParamRenames, RenameMethodCallBasedOnParameter::class);
+
+        $this->callsWithParamRenames = $callsWithParamRenames;
+    }
+
+    private function matchTypeAndMethodName(MethodCall $methodCall): ?RenameMethodCallBasedOnParameter
+    {
+        if (count($methodCall->args) < 1) {
+            return null;
+        }
+
+        $firstArgValue = $methodCall->args[0]->value;
+
+        foreach ($this->callsWithParamRenames as $callWithParamRename) {
+            if (! $this->isObjectType($methodCall->var, $callWithParamRename->getOldObjectType())) {
+                continue;
+            }
+
+            if (! $this->isName($methodCall->name, $callWithParamRename->getOldMethod())) {
+                continue;
+            }
+
+            if (! $this->valueResolver->isValue($firstArgValue, $callWithParamRename->getParameterName())) {
+                continue;
+            }
+
+            return $callWithParamRename;
+        }
+
+        return null;
+    }
+}

--- a/src/RectorCakePHP/Rector/MethodCall/RenameMethodCallBasedOnParameterRector.php
+++ b/src/RectorCakePHP/Rector/MethodCall/RenameMethodCallBasedOnParameterRector.php
@@ -24,7 +24,7 @@ final class RenameMethodCallBasedOnParameterRector extends AbstractRector implem
     /**
      * @var string
      */
-    final public const CALLS_WITH_PARAM_RENAMES = 'calls_with_param_renames';
+    public const CALLS_WITH_PARAM_RENAMES = 'calls_with_param_renames';
 
     /**
      * @var \Rector\CakePHP\ValueObject\RenameMethodCallBasedOnParameter[]

--- a/src/RectorCakePHP/Rector/MethodCall/RenameMethodCallBasedOnParameterRector.php
+++ b/src/RectorCakePHP/Rector/MethodCall/RenameMethodCallBasedOnParameterRector.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Rector\CakePHP\Rector\MethodCall;
@@ -28,7 +27,7 @@ final class RenameMethodCallBasedOnParameterRector extends AbstractRector implem
     final public const CALLS_WITH_PARAM_RENAMES = 'calls_with_param_renames';
 
     /**
-     * @var RenameMethodCallBasedOnParameter[]
+     * @var \Rector\CakePHP\ValueObject\RenameMethodCallBasedOnParameter[]
      */
     private array $callsWithParamRenames = [];
 
@@ -40,6 +39,7 @@ final class RenameMethodCallBasedOnParameterRector extends AbstractRector implem
                 new RenameMethodCallBasedOnParameter('ServerRequest', 'withParam', 'paging', 'withAttribute'),
             ],
         ];
+
         return new RuleDefinition(
             'Changes method calls based on matching the first parameter value.',
             [
@@ -65,7 +65,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @return array<class-string<Node>>
+     * @return array<class-string<\PhpParser\Node>>
      */
     public function getNodeTypes(): array
     {
@@ -73,7 +73,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param MethodCall $node
+     * @param \PhpParser\Node\Expr\MethodCall $node
      */
     public function refactor(Node $node): ?Node
     {

--- a/src/RectorCakePHP/Rector/Namespace_/AppUsesStaticCallToUseStatementRector.php
+++ b/src/RectorCakePHP/Rector/Namespace_/AppUsesStaticCallToUseStatementRector.php
@@ -23,7 +23,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class AppUsesStaticCallToUseStatementRector extends AbstractRector
 {
     public function __construct(
-        private readonly CakePHPFullyQualifiedClassNameResolver $cakePHPFullyQualifiedClassNameResolver
+        private CakePHPFullyQualifiedClassNameResolver $cakePHPFullyQualifiedClassNameResolver
     ) {
     }
 

--- a/src/RectorCakePHP/Rector/Namespace_/AppUsesStaticCallToUseStatementRector.php
+++ b/src/RectorCakePHP/Rector/Namespace_/AppUsesStaticCallToUseStatementRector.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Rector\CakePHP\Rector\Namespace_;
@@ -8,7 +7,6 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Stmt\Declare_;
 use PhpParser\Node\Stmt\Namespace_;
-use PhpParser\Node\Stmt\Use_;
 use PHPStan\Type\ObjectType;
 use Rector\CakePHP\Naming\CakePHPFullyQualifiedClassNameResolver;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
@@ -49,7 +47,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @return array<class-string<Node>>
+     * @return array<class-string<\PhpParser\Node>>
      */
     public function getNodeTypes(): array
     {
@@ -57,7 +55,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param FileWithoutNamespace|Namespace_ $node
+     * @param \Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace|\PhpParser\Node\Stmt\Namespace_ $node
      */
     public function refactor(Node $node): ?Node
     {
@@ -73,6 +71,7 @@ CODE_SAMPLE
 
         if ($node instanceof Namespace_) {
             $node->stmts = array_merge($uses, $node->stmts);
+
             return $node;
         }
 
@@ -80,11 +79,11 @@ CODE_SAMPLE
     }
 
     /**
-     * @return StaticCall[]
+     * @return \PhpParser\Node\Expr\StaticCall[]
      */
     private function collectAppUseStaticCalls(Node $node): array
     {
-        /** @var StaticCall[] $appUsesStaticCalls */
+        /** @var \PhpParser\Node\Expr\StaticCall[] $appUsesStaticCalls */
         $appUsesStaticCalls = $this->betterNodeFinder->find($node, function (Node $node): bool {
             if (! $node instanceof StaticCall) {
                 return false;
@@ -102,7 +101,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param StaticCall[] $staticCalls
+     * @param \PhpParser\Node\Expr\StaticCall[] $staticCalls
      * @return string[]
      */
     private function resolveNamesFromStaticCalls(array $staticCalls): array
@@ -116,7 +115,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param Use_[] $uses
+     * @param \PhpParser\Node\Stmt\Use_[] $fileWithoutNamespace
      */
     private function refactorFile(FileWithoutNamespace $fileWithoutNamespace, array $uses): ?FileWithoutNamespace
     {
@@ -132,6 +131,7 @@ CODE_SAMPLE
         }
 
         $fileWithoutNamespace->stmts = array_merge($uses, $fileWithoutNamespace->stmts);
+
         return $fileWithoutNamespace;
     }
 
@@ -150,7 +150,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param Use_[] $uses
+     * @param \PhpParser\Node\Stmt\Use_[] $fileWithoutNamespace
      */
     private function refactorFileWithDeclare(
         FileWithoutNamespace $fileWithoutNamespace,

--- a/src/RectorCakePHP/Rector/Namespace_/AppUsesStaticCallToUseStatementRector.php
+++ b/src/RectorCakePHP/Rector/Namespace_/AppUsesStaticCallToUseStatementRector.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CakePHP\Rector\Namespace_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Stmt\Declare_;
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\Node\Stmt\Use_;
+use PHPStan\Type\ObjectType;
+use Rector\CakePHP\Naming\CakePHPFullyQualifiedClassNameResolver;
+use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see https://github.com/cakephp/upgrade/blob/756410c8b7d5aff9daec3fa1fe750a3858d422ac/src/Shell/Task/AppUsesTask.php
+ * @see https://github.com/cakephp/upgrade/search?q=uses&unscoped_q=uses
+ *
+ * @see \Rector\CakePHP\Tests\Rector\Namespace_\AppUsesStaticCallToUseStatementRector\AppUsesStaticCallToUseStatementRectorTest
+ */
+final class AppUsesStaticCallToUseStatementRector extends AbstractRector
+{
+    public function __construct(
+        private readonly CakePHPFullyQualifiedClassNameResolver $cakePHPFullyQualifiedClassNameResolver
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Change App::uses() to use imports', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+App::uses('NotificationListener', 'Event');
+
+CakeEventManager::instance()->attach(new NotificationListener());
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+use Event\NotificationListener;
+
+CakeEventManager::instance()->attach(new NotificationListener());
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [FileWithoutNamespace::class, Namespace_::class];
+    }
+
+    /**
+     * @param FileWithoutNamespace|Namespace_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $appUsesStaticCalls = $this->collectAppUseStaticCalls($node);
+        if ($appUsesStaticCalls === []) {
+            return null;
+        }
+
+        $this->nodeRemover->removeNodes($appUsesStaticCalls);
+
+        $names = $this->resolveNamesFromStaticCalls($appUsesStaticCalls);
+        $uses = $this->nodeFactory->createUsesFromNames($names);
+
+        if ($node instanceof Namespace_) {
+            $node->stmts = array_merge($uses, $node->stmts);
+            return $node;
+        }
+
+        return $this->refactorFile($node, $uses);
+    }
+
+    /**
+     * @return StaticCall[]
+     */
+    private function collectAppUseStaticCalls(Node $node): array
+    {
+        /** @var StaticCall[] $appUsesStaticCalls */
+        $appUsesStaticCalls = $this->betterNodeFinder->find($node, function (Node $node): bool {
+            if (! $node instanceof StaticCall) {
+                return false;
+            }
+
+            $callerType = $this->nodeTypeResolver->getType($node->class);
+            if (! $callerType->isSuperTypeOf(new ObjectType('App'))->yes()) {
+                return false;
+            }
+
+            return $this->isName($node->name, 'uses');
+        });
+
+        return $appUsesStaticCalls;
+    }
+
+    /**
+     * @param StaticCall[] $staticCalls
+     * @return string[]
+     */
+    private function resolveNamesFromStaticCalls(array $staticCalls): array
+    {
+        $names = [];
+        foreach ($staticCalls as $staticCall) {
+            $names[] = $this->createFullyQualifiedNameFromAppUsesStaticCall($staticCall);
+        }
+
+        return $names;
+    }
+
+    /**
+     * @param Use_[] $uses
+     */
+    private function refactorFile(FileWithoutNamespace $fileWithoutNamespace, array $uses): ?FileWithoutNamespace
+    {
+        $hasNamespace = $this->betterNodeFinder->findFirstInstanceOf($fileWithoutNamespace, Namespace_::class);
+        // already handled above
+        if ($hasNamespace !== null) {
+            return null;
+        }
+
+        $hasDeclare = $this->betterNodeFinder->findFirstInstanceOf($fileWithoutNamespace, Declare_::class);
+        if ($hasDeclare !== null) {
+            return $this->refactorFileWithDeclare($fileWithoutNamespace, $uses);
+        }
+
+        $fileWithoutNamespace->stmts = array_merge($uses, $fileWithoutNamespace->stmts);
+        return $fileWithoutNamespace;
+    }
+
+    private function createFullyQualifiedNameFromAppUsesStaticCall(StaticCall $staticCall): string
+    {
+        /** @var string $shortClassName */
+        $shortClassName = $this->valueResolver->getValue($staticCall->args[0]->value);
+
+        /** @var string $namespaceName */
+        $namespaceName = $this->valueResolver->getValue($staticCall->args[1]->value);
+
+        return $this->cakePHPFullyQualifiedClassNameResolver->resolveFromPseudoNamespaceAndShortClassName(
+            $namespaceName,
+            $shortClassName
+        );
+    }
+
+    /**
+     * @param Use_[] $uses
+     */
+    private function refactorFileWithDeclare(
+        FileWithoutNamespace $fileWithoutNamespace,
+        array $uses
+    ): FileWithoutNamespace {
+        $newStmts = [];
+        foreach ($fileWithoutNamespace->stmts as $stmt) {
+            $newStmts[] = $stmt;
+
+            if ($stmt instanceof Declare_) {
+                foreach ($uses as $use) {
+                    $newStmts[] = $use;
+                }
+
+                continue;
+            }
+        }
+
+        return new FileWithoutNamespace($newStmts);
+    }
+}

--- a/src/RectorCakePHP/Rector/Property/ChangeSnakedFixtureNameToPascalRector.php
+++ b/src/RectorCakePHP/Rector/Property/ChangeSnakedFixtureNameToPascalRector.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Rector\CakePHP\Rector\Property;
@@ -51,7 +50,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @return array<class-string<Node>>
+     * @return array<class-string<\PhpParser\Node>>
      */
     public function getNodeTypes(): array
     {
@@ -59,7 +58,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param Property $node
+     * @param \PhpParser\Node\Stmt\Property $node
      */
     public function refactor(Node $node): ?Node
     {
@@ -109,6 +108,7 @@ CODE_SAMPLE
         $pascalCaseTableParts = array_map(
             function (string $token): string {
                 $tokenUnicodeString = new UnicodeString($token);
+
                 return ucfirst($tokenUnicodeString->camel()->toString());
             },
             $tableParts

--- a/src/RectorCakePHP/Rector/Property/ChangeSnakedFixtureNameToPascalRector.php
+++ b/src/RectorCakePHP/Rector/Property/ChangeSnakedFixtureNameToPascalRector.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CakePHP\Rector\Property;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\Stmt\PropertyProperty;
+use Rector\Core\Rector\AbstractRector;
+use Symfony\Component\String\UnicodeString;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\CakePHP\Tests\Rector\Property\ChangeSnakedFixtureNameToPascal\ChangeSnakedFixtureNameToPascalTest
+ *
+ * @see https://book.cakephp.org/3.0/en/appendices/3-7-migration-guide.html
+ */
+final class ChangeSnakedFixtureNameToPascalRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Changes $fixtures style from snake_case to PascalCase.', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeTest
+{
+    protected $fixtures = [
+        'app.posts',
+        'app.users',
+        'some_plugin.posts/special_posts',
+    ];
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+class SomeTest
+{
+    protected $fixtures = [
+        'app.Posts',
+        'app.Users',
+        'some_plugin.Posts/SpecialPosts',
+    ];
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Property::class];
+    }
+
+    /**
+     * @param Property $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $classLike = $this->betterNodeFinder->findParentType($node, ClassLike::class);
+        if (! $classLike instanceof ClassLike) {
+            return null;
+        }
+
+        if (! $this->isName($node, 'fixtures')) {
+            return null;
+        }
+
+        foreach ($node->props as $prop) {
+            $this->refactorPropertyWithArrayDefault($prop);
+        }
+
+        return $node;
+    }
+
+    private function refactorPropertyWithArrayDefault(PropertyProperty $propertyProperty): void
+    {
+        if (! $propertyProperty->default instanceof Array_) {
+            return;
+        }
+
+        $array = $propertyProperty->default;
+        foreach ($array->items as $arrayItem) {
+            if (! $arrayItem instanceof ArrayItem) {
+                continue;
+            }
+
+            $itemValue = $arrayItem->value;
+            if (! $itemValue instanceof String_) {
+                continue;
+            }
+
+            $this->renameFixtureName($itemValue);
+        }
+    }
+
+    private function renameFixtureName(String_ $string): void
+    {
+        [$prefix, $table] = explode('.', $string->value);
+
+        $tableParts = explode('/', $table);
+
+        $pascalCaseTableParts = array_map(
+            function (string $token): string {
+                $tokenUnicodeString = new UnicodeString($token);
+                return ucfirst($tokenUnicodeString->camel()->toString());
+            },
+            $tableParts
+        );
+
+        $table = implode('/', $pascalCaseTableParts);
+
+        $string->value = sprintf('%s.%s', $prefix, $table);
+    }
+}

--- a/src/RectorCakePHP/Set/CakePHPLevelSetList.php
+++ b/src/RectorCakePHP/Set/CakePHPLevelSetList.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CakePHP\Set;
+
+use Rector\Set\Contract\SetListInterface;
+
+final class CakePHPLevelSetList implements SetListInterface
+{
+    /**
+     * @var string
+     */
+    final public const UP_TO_CAKEPHP_34 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-34.php';
+
+    /**
+     * @var string
+     */
+    final public const UP_TO_CAKEPHP_35 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-35.php';
+
+    /**
+     * @var string
+     */
+    final public const UP_TO_CAKEPHP_36 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-36.php';
+
+    /**
+     * @var string
+     */
+    final public const UP_TO_CAKEPHP_37 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-37.php';
+
+    /**
+     * @var string
+     */
+    final public const UP_TO_CAKEPHP_38 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-38.php';
+
+    /**
+     * @var string
+     */
+    final public const UP_TO_CAKEPHP_40 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-40.php';
+
+    /**
+     * @var string
+     */
+    final public const UP_TO_CAKEPHP_41 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-41.php';
+
+    /**
+     * @var string
+     */
+    final public const UP_TO_CAKEPHP_42 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-42.php';
+
+    /**
+     * @var string
+     */
+    final public const UP_TO_CAKEPHP_43 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-43.php';
+
+    /**
+     * @var string
+     */
+    final public const UP_TO_CAKEPHP_44 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-44.php';
+}

--- a/src/RectorCakePHP/Set/CakePHPLevelSetList.php
+++ b/src/RectorCakePHP/Set/CakePHPLevelSetList.php
@@ -10,50 +10,50 @@ final class CakePHPLevelSetList implements SetListInterface
     /**
      * @var string
      */
-    final public const UP_TO_CAKEPHP_34 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-34.php';
+    public const UP_TO_CAKEPHP_34 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-34.php';
 
     /**
      * @var string
      */
-    final public const UP_TO_CAKEPHP_35 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-35.php';
+    public const UP_TO_CAKEPHP_35 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-35.php';
 
     /**
      * @var string
      */
-    final public const UP_TO_CAKEPHP_36 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-36.php';
+    public const UP_TO_CAKEPHP_36 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-36.php';
 
     /**
      * @var string
      */
-    final public const UP_TO_CAKEPHP_37 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-37.php';
+    public const UP_TO_CAKEPHP_37 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-37.php';
 
     /**
      * @var string
      */
-    final public const UP_TO_CAKEPHP_38 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-38.php';
+    public const UP_TO_CAKEPHP_38 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-38.php';
 
     /**
      * @var string
      */
-    final public const UP_TO_CAKEPHP_40 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-40.php';
+    public const UP_TO_CAKEPHP_40 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-40.php';
 
     /**
      * @var string
      */
-    final public const UP_TO_CAKEPHP_41 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-41.php';
+    public const UP_TO_CAKEPHP_41 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-41.php';
 
     /**
      * @var string
      */
-    final public const UP_TO_CAKEPHP_42 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-42.php';
+    public const UP_TO_CAKEPHP_42 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-42.php';
 
     /**
      * @var string
      */
-    final public const UP_TO_CAKEPHP_43 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-43.php';
+    public const UP_TO_CAKEPHP_43 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-43.php';
 
     /**
      * @var string
      */
-    final public const UP_TO_CAKEPHP_44 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-44.php';
+    public const UP_TO_CAKEPHP_44 = __DIR__ . '/../../../config/sets/level/up-to-cakephp-44.php';
 }

--- a/src/RectorCakePHP/Set/CakePHPLevelSetList.php
+++ b/src/RectorCakePHP/Set/CakePHPLevelSetList.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Rector\CakePHP\Set;

--- a/src/RectorCakePHP/Set/CakePHPSetList.php
+++ b/src/RectorCakePHP/Set/CakePHPSetList.php
@@ -10,60 +10,60 @@ final class CakePHPSetList implements SetListInterface
     /**
      * @var string
      */
-    final public const CAKEPHP_30 = __DIR__ . '/../../../config/sets/cakephp30.php';
+    public const CAKEPHP_30 = __DIR__ . '/../../../config/sets/cakephp30.php';
 
     /**
      * @var string
      */
-    final public const CAKEPHP_34 = __DIR__ . '/../../../config/sets/cakephp34.php';
+    public const CAKEPHP_34 = __DIR__ . '/../../../config/sets/cakephp34.php';
 
     /**
      * @var string
      */
-    final public const CAKEPHP_35 = __DIR__ . '/../../../config/sets/cakephp35.php';
+    public const CAKEPHP_35 = __DIR__ . '/../../../config/sets/cakephp35.php';
 
     /**
      * @var string
      */
-    final public const CAKEPHP_36 = __DIR__ . '/../../../config/sets/cakephp36.php';
+    public const CAKEPHP_36 = __DIR__ . '/../../../config/sets/cakephp36.php';
 
     /**
      * @var string
      */
-    final public const CAKEPHP_37 = __DIR__ . '/../../../config/sets/cakephp37.php';
+    public const CAKEPHP_37 = __DIR__ . '/../../../config/sets/cakephp37.php';
 
     /**
      * @var string
      */
-    final public const CAKEPHP_38 = __DIR__ . '/../../../config/sets/cakephp38.php';
+    public const CAKEPHP_38 = __DIR__ . '/../../../config/sets/cakephp38.php';
 
     /**
      * @var string
      */
-    final public const CAKEPHP_40 = __DIR__ . '/../../../config/sets/cakephp40.php';
+    public const CAKEPHP_40 = __DIR__ . '/../../../config/sets/cakephp40.php';
 
     /**
      * @var string
      */
-    final public const CAKEPHP_41 = __DIR__ . '/../../../config/sets/cakephp41.php';
+    public const CAKEPHP_41 = __DIR__ . '/../../../config/sets/cakephp41.php';
 
     /**
      * @var string
      */
-    final public const CAKEPHP_42 = __DIR__ . '/../../../config/sets/cakephp42.php';
+    public const CAKEPHP_42 = __DIR__ . '/../../../config/sets/cakephp42.php';
 
     /**
      * @var string
      */
-    final public const CAKEPHP_43 = __DIR__ . '/../../../config/sets/cakephp43.php';
+    public const CAKEPHP_43 = __DIR__ . '/../../../config/sets/cakephp43.php';
 
     /**
      * @var string
      */
-    final public const CAKEPHP_44 = __DIR__ . '/../../../config/sets/cakephp44.php';
+    public const CAKEPHP_44 = __DIR__ . '/../../../config/sets/cakephp44.php';
 
     /**
      * @var string
      */
-    final public const CAKEPHP_FLUENT_OPTIONS = __DIR__ . '/../../../config/sets/cakephp-fluent-options.php';
+    public const CAKEPHP_FLUENT_OPTIONS = __DIR__ . '/../../../config/sets/cakephp-fluent-options.php';
 }

--- a/src/RectorCakePHP/Set/CakePHPSetList.php
+++ b/src/RectorCakePHP/Set/CakePHPSetList.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Rector\CakePHP\Set;

--- a/src/RectorCakePHP/Set/CakePHPSetList.php
+++ b/src/RectorCakePHP/Set/CakePHPSetList.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CakePHP\Set;
+
+use Rector\Set\Contract\SetListInterface;
+
+final class CakePHPSetList implements SetListInterface
+{
+    /**
+     * @var string
+     */
+    final public const CAKEPHP_30 = __DIR__ . '/../../../config/sets/cakephp30.php';
+
+    /**
+     * @var string
+     */
+    final public const CAKEPHP_34 = __DIR__ . '/../../../config/sets/cakephp34.php';
+
+    /**
+     * @var string
+     */
+    final public const CAKEPHP_35 = __DIR__ . '/../../../config/sets/cakephp35.php';
+
+    /**
+     * @var string
+     */
+    final public const CAKEPHP_36 = __DIR__ . '/../../../config/sets/cakephp36.php';
+
+    /**
+     * @var string
+     */
+    final public const CAKEPHP_37 = __DIR__ . '/../../../config/sets/cakephp37.php';
+
+    /**
+     * @var string
+     */
+    final public const CAKEPHP_38 = __DIR__ . '/../../../config/sets/cakephp38.php';
+
+    /**
+     * @var string
+     */
+    final public const CAKEPHP_40 = __DIR__ . '/../../../config/sets/cakephp40.php';
+
+    /**
+     * @var string
+     */
+    final public const CAKEPHP_41 = __DIR__ . '/../../../config/sets/cakephp41.php';
+
+    /**
+     * @var string
+     */
+    final public const CAKEPHP_42 = __DIR__ . '/../../../config/sets/cakephp42.php';
+
+    /**
+     * @var string
+     */
+    final public const CAKEPHP_43 = __DIR__ . '/../../../config/sets/cakephp43.php';
+
+    /**
+     * @var string
+     */
+    final public const CAKEPHP_44 = __DIR__ . '/../../../config/sets/cakephp44.php';
+
+    /**
+     * @var string
+     */
+    final public const CAKEPHP_FLUENT_OPTIONS = __DIR__ . '/../../../config/sets/cakephp-fluent-options.php';
+}

--- a/src/RectorCakePHP/ValueObject/ArrayItemsAndFluentClass.php
+++ b/src/RectorCakePHP/ValueObject/ArrayItemsAndFluentClass.php
@@ -1,17 +1,13 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Rector\CakePHP\ValueObject;
 
-use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\ArrayItem;
-
 final class ArrayItemsAndFluentClass
 {
     /**
-     * @param ArrayItem[] $arrayItems
-     * @param array<string, Expr> $fluentCalls
+     * @param \PhpParser\Node\Expr\ArrayItem[] $arrayItems
+     * @param array<string, \PhpParser\Node\Expr> $fluentCalls
      */
     public function __construct(
         private readonly array $arrayItems,
@@ -20,7 +16,7 @@ final class ArrayItemsAndFluentClass
     }
 
     /**
-     * @return ArrayItem[]
+     * @return \PhpParser\Node\Expr\ArrayItem[]
      */
     public function getArrayItems(): array
     {
@@ -28,7 +24,7 @@ final class ArrayItemsAndFluentClass
     }
 
     /**
-     * @return array<string, Expr>
+     * @return array<string, \PhpParser\Node\Expr>
      */
     public function getFluentCalls(): array
     {

--- a/src/RectorCakePHP/ValueObject/ArrayItemsAndFluentClass.php
+++ b/src/RectorCakePHP/ValueObject/ArrayItemsAndFluentClass.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CakePHP\ValueObject;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrayItem;
+
+final class ArrayItemsAndFluentClass
+{
+    /**
+     * @param ArrayItem[] $arrayItems
+     * @param array<string, Expr> $fluentCalls
+     */
+    public function __construct(
+        private readonly array $arrayItems,
+        private readonly array $fluentCalls
+    ) {
+    }
+
+    /**
+     * @return ArrayItem[]
+     */
+    public function getArrayItems(): array
+    {
+        return $this->arrayItems;
+    }
+
+    /**
+     * @return array<string, Expr>
+     */
+    public function getFluentCalls(): array
+    {
+        return $this->fluentCalls;
+    }
+}

--- a/src/RectorCakePHP/ValueObject/ArrayItemsAndFluentClass.php
+++ b/src/RectorCakePHP/ValueObject/ArrayItemsAndFluentClass.php
@@ -10,8 +10,8 @@ final class ArrayItemsAndFluentClass
      * @param array<string, \PhpParser\Node\Expr> $fluentCalls
      */
     public function __construct(
-        private readonly array $arrayItems,
-        private readonly array $fluentCalls
+        private array $arrayItems,
+        private array $fluentCalls
     ) {
     }
 

--- a/src/RectorCakePHP/ValueObject/ArrayToFluentCall.php
+++ b/src/RectorCakePHP/ValueObject/ArrayToFluentCall.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Rector\CakePHP\ValueObject;
@@ -7,7 +6,7 @@ namespace Rector\CakePHP\ValueObject;
 final class ArrayToFluentCall
 {
     /**
-     * @param array<string, string> $arrayKeysToFluentCalls
+     * @param array<string, string> $class
      */
     public function __construct(
         private readonly string $class,

--- a/src/RectorCakePHP/ValueObject/ArrayToFluentCall.php
+++ b/src/RectorCakePHP/ValueObject/ArrayToFluentCall.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CakePHP\ValueObject;
+
+final class ArrayToFluentCall
+{
+    /**
+     * @param array<string, string> $arrayKeysToFluentCalls
+     */
+    public function __construct(
+        private readonly string $class,
+        private readonly array $arrayKeysToFluentCalls
+    ) {
+    }
+
+    public function getClass(): string
+    {
+        return $this->class;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getArrayKeysToFluentCalls(): array
+    {
+        return $this->arrayKeysToFluentCalls;
+    }
+}

--- a/src/RectorCakePHP/ValueObject/ArrayToFluentCall.php
+++ b/src/RectorCakePHP/ValueObject/ArrayToFluentCall.php
@@ -9,8 +9,8 @@ final class ArrayToFluentCall
      * @param array<string, string> $class
      */
     public function __construct(
-        private readonly string $class,
-        private readonly array $arrayKeysToFluentCalls
+        private string $class,
+        private array $arrayKeysToFluentCalls
     ) {
     }
 

--- a/src/RectorCakePHP/ValueObject/FactoryMethod.php
+++ b/src/RectorCakePHP/ValueObject/FactoryMethod.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CakePHP\ValueObject;
+
+use PHPStan\Type\ObjectType;
+
+final class FactoryMethod
+{
+    public function __construct(
+        private readonly string $type,
+        private readonly string $method,
+        private readonly string $newClass,
+        private readonly int $position
+    ) {
+    }
+
+    public function getObjectType(): ObjectType
+    {
+        return new ObjectType($this->type);
+    }
+
+    public function getMethod(): string
+    {
+        return $this->method;
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function getNewClass(): string
+    {
+        return $this->newClass;
+    }
+}

--- a/src/RectorCakePHP/ValueObject/FactoryMethod.php
+++ b/src/RectorCakePHP/ValueObject/FactoryMethod.php
@@ -8,10 +8,10 @@ use PHPStan\Type\ObjectType;
 final class FactoryMethod
 {
     public function __construct(
-        private readonly string $type,
-        private readonly string $method,
-        private readonly string $newClass,
-        private readonly int $position
+        private string $type,
+        private string $method,
+        private string $newClass,
+        private int $position
     ) {
     }
 

--- a/src/RectorCakePHP/ValueObject/FactoryMethod.php
+++ b/src/RectorCakePHP/ValueObject/FactoryMethod.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Rector\CakePHP\ValueObject;

--- a/src/RectorCakePHP/ValueObject/ModalToGetSet.php
+++ b/src/RectorCakePHP/ValueObject/ModalToGetSet.php
@@ -7,17 +7,23 @@ use PHPStan\Type\ObjectType;
 
 final class ModalToGetSet
 {
-    private readonly string $getMethod;
+    /**
+     * @readonly
+     */
+    private string $getMethod;
 
-    private readonly string $setMethod;
+    /**
+     * @readonly
+     */
+    private string $setMethod;
 
     public function __construct(
-        private readonly string $type,
-        private readonly string $unprefixedMethod,
+        private string $type,
+        private string $unprefixedMethod,
         ?string $getMethod = null,
         ?string $setMethod = null,
-        private readonly int $minimalSetterArgumentCount = 1,
-        private readonly ?string $firstArgumentType = null
+        private int $minimalSetterArgumentCount = 1,
+        private ?string $firstArgumentType = null
     ) {
         $this->getMethod = $getMethod ?? 'get' . ucfirst($unprefixedMethod);
         $this->setMethod = $setMethod ?? 'set' . ucfirst($unprefixedMethod);

--- a/src/RectorCakePHP/ValueObject/ModalToGetSet.php
+++ b/src/RectorCakePHP/ValueObject/ModalToGetSet.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CakePHP\ValueObject;
+
+use PHPStan\Type\ObjectType;
+
+final class ModalToGetSet
+{
+    private readonly string $getMethod;
+
+    private readonly string $setMethod;
+
+    public function __construct(
+        private readonly string $type,
+        private readonly string $unprefixedMethod,
+        ?string $getMethod = null,
+        ?string $setMethod = null,
+        private readonly int $minimalSetterArgumentCount = 1,
+        private readonly ?string $firstArgumentType = null
+    ) {
+        $this->getMethod = $getMethod ?? 'get' . ucfirst($unprefixedMethod);
+        $this->setMethod = $setMethod ?? 'set' . ucfirst($unprefixedMethod);
+    }
+
+    public function getObjectType(): ObjectType
+    {
+        return new ObjectType($this->type);
+    }
+
+    public function getUnprefixedMethod(): string
+    {
+        return $this->unprefixedMethod;
+    }
+
+    public function getGetMethod(): string
+    {
+        return $this->getMethod;
+    }
+
+    public function getSetMethod(): string
+    {
+        return $this->setMethod;
+    }
+
+    public function getMinimalSetterArgumentCount(): int
+    {
+        return $this->minimalSetterArgumentCount;
+    }
+
+    public function getFirstArgumentType(): ?string
+    {
+        return $this->firstArgumentType;
+    }
+}

--- a/src/RectorCakePHP/ValueObject/ModalToGetSet.php
+++ b/src/RectorCakePHP/ValueObject/ModalToGetSet.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Rector\CakePHP\ValueObject;

--- a/src/RectorCakePHP/ValueObject/RemoveIntermediaryMethod.php
+++ b/src/RectorCakePHP/ValueObject/RemoveIntermediaryMethod.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CakePHP\ValueObject;
+
+final class RemoveIntermediaryMethod
+{
+    public function __construct(
+        private readonly string $firstMethod,
+        private readonly string $secondMethod,
+        private readonly string $finalMethod,
+    ) {
+    }
+
+    public function getFirstMethod(): string
+    {
+        return $this->firstMethod;
+    }
+
+    public function getSecondMethod(): string
+    {
+        return $this->secondMethod;
+    }
+
+    public function getFinalMethod(): string
+    {
+        return $this->finalMethod;
+    }
+}

--- a/src/RectorCakePHP/ValueObject/RemoveIntermediaryMethod.php
+++ b/src/RectorCakePHP/ValueObject/RemoveIntermediaryMethod.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Rector\CakePHP\ValueObject;

--- a/src/RectorCakePHP/ValueObject/RemoveIntermediaryMethod.php
+++ b/src/RectorCakePHP/ValueObject/RemoveIntermediaryMethod.php
@@ -6,9 +6,9 @@ namespace Rector\CakePHP\ValueObject;
 final class RemoveIntermediaryMethod
 {
     public function __construct(
-        private readonly string $firstMethod,
-        private readonly string $secondMethod,
-        private readonly string $finalMethod,
+        private string $firstMethod,
+        private string $secondMethod,
+        private string $finalMethod,
     ) {
     }
 

--- a/src/RectorCakePHP/ValueObject/RenameMethodCallBasedOnParameter.php
+++ b/src/RectorCakePHP/ValueObject/RenameMethodCallBasedOnParameter.php
@@ -8,10 +8,10 @@ use PHPStan\Type\ObjectType;
 final class RenameMethodCallBasedOnParameter
 {
     public function __construct(
-        private readonly string $oldClass,
-        private readonly string $oldMethod,
-        private readonly string $parameterName,
-        private readonly string $newMethod
+        private string $oldClass,
+        private string $oldMethod,
+        private string $parameterName,
+        private string $newMethod
     ) {
     }
 

--- a/src/RectorCakePHP/ValueObject/RenameMethodCallBasedOnParameter.php
+++ b/src/RectorCakePHP/ValueObject/RenameMethodCallBasedOnParameter.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Rector\CakePHP\ValueObject;

--- a/src/RectorCakePHP/ValueObject/RenameMethodCallBasedOnParameter.php
+++ b/src/RectorCakePHP/ValueObject/RenameMethodCallBasedOnParameter.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CakePHP\ValueObject;
+
+use PHPStan\Type\ObjectType;
+
+final class RenameMethodCallBasedOnParameter
+{
+    public function __construct(
+        private readonly string $oldClass,
+        private readonly string $oldMethod,
+        private readonly string $parameterName,
+        private readonly string $newMethod
+    ) {
+    }
+
+    public function getOldMethod(): string
+    {
+        return $this->oldMethod;
+    }
+
+    public function getParameterName(): string
+    {
+        return $this->parameterName;
+    }
+
+    public function getNewMethod(): string
+    {
+        return $this->newMethod;
+    }
+
+    public function getOldObjectType(): ObjectType
+    {
+        return new ObjectType($this->oldClass);
+    }
+}

--- a/tests/Rector/MethodCall/ArrayToFluentCallRector/ArrayToFluentCallRectorTest.php
+++ b/tests/Rector/MethodCall/ArrayToFluentCallRector/ArrayToFluentCallRectorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\ArrayToFluentCallRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ArrayToFluentCallRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/MethodCall/ArrayToFluentCallRector/Fixture/array_to_fluent_call.php.inc
+++ b/tests/Rector/MethodCall/ArrayToFluentCallRector/Fixture/array_to_fluent_call.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\ArrayToFluentCallRector\Fixture;
+
+use Rector\CakePHP\Tests\Rector\MethodCall\ArrayToFluentCallRector\Source;
+
+function arrayToFluentCall2()
+{
+    $factory = new Source\FactoryClass();
+
+    $factory->buildClass('foo', [
+        'name' => 'bar',
+        'size' => 2,
+    ]);
+
+    $factory->buildClass('foo', ['name' => 'bar'])
+        ->setSize(3)
+        ->doSomething();
+
+    $factory->buildClass('foo', [
+        'name' => 'bar',
+        'baz' => 4,
+    ]);
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\ArrayToFluentCallRector\Fixture;
+
+use Rector\CakePHP\Tests\Rector\MethodCall\ArrayToFluentCallRector\Source;
+
+function arrayToFluentCall2()
+{
+    $factory = new Source\FactoryClass();
+
+    $factory->buildClass('foo')->setName('bar')->setSize(2);
+
+    $factory->buildClass('foo')->setName('bar')
+        ->setSize(3)
+        ->doSomething();
+
+    $factory->buildClass('foo', [
+        'baz' => 4,
+    ])->setName('bar');
+}
+
+?>

--- a/tests/Rector/MethodCall/ArrayToFluentCallRector/Fixture/fluent_factory.php.inc
+++ b/tests/Rector/MethodCall/ArrayToFluentCallRector/Fixture/fluent_factory.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\ArrayToFluentCallRector\Fixture;
+
+use Rector\CakePHP\Tests\Rector\MethodCall\ArrayToFluentCallRector\Source;
+
+function arrayToFluentCall()
+{
+    $factory = new Source\FactoryClass();
+
+    $factory->buildClass('foo');
+
+    $factory->buildClass('foo', []);
+
+    $factory->buildClass('foo', ['baz' => 1]);
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\ArrayToFluentCallRector\Fixture;
+
+use Rector\CakePHP\Tests\Rector\MethodCall\ArrayToFluentCallRector\Source;
+
+function arrayToFluentCall()
+{
+    $factory = new Source\FactoryClass();
+
+    $factory->buildClass('foo');
+
+    $factory->buildClass('foo');
+
+    $factory->buildClass('foo', ['baz' => 1]);
+}
+
+?>

--- a/tests/Rector/MethodCall/ArrayToFluentCallRector/Source/ConfigurableClass.php
+++ b/tests/Rector/MethodCall/ArrayToFluentCallRector/Source/ConfigurableClass.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\ArrayToFluentCallRector\Source;
+
+class ConfigurableClass
+{
+    public function setName(string $name): self
+    {
+        return $this;
+    }
+
+    public function setSize(int $size): self
+    {
+        return $this;
+    }
+
+    public function doSomething(): void
+    {
+    }
+}

--- a/tests/Rector/MethodCall/ArrayToFluentCallRector/Source/FactoryClass.php
+++ b/tests/Rector/MethodCall/ArrayToFluentCallRector/Source/FactoryClass.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\ArrayToFluentCallRector\Source;
+
+class FactoryClass
+{
+    public function buildClass($arg1, array $options = []): ConfigurableClass
+    {
+        $configurableClass = new ConfigurableClass();
+
+        $configurableClass->setName($options['name']);
+
+        return $configurableClass;
+    }
+}

--- a/tests/Rector/MethodCall/ArrayToFluentCallRector/config/configured_rule.php
+++ b/tests/Rector/MethodCall/ArrayToFluentCallRector/config/configured_rule.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CakePHP\Rector\MethodCall\ArrayToFluentCallRector;
+
+use Rector\CakePHP\Tests\Rector\MethodCall\ArrayToFluentCallRector\Source\ConfigurableClass;
+use Rector\CakePHP\Tests\Rector\MethodCall\ArrayToFluentCallRector\Source\FactoryClass;
+use Rector\CakePHP\ValueObject\ArrayToFluentCall;
+use Rector\CakePHP\ValueObject\FactoryMethod;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->ruleWithConfiguration(ArrayToFluentCallRector::class, [
+        ArrayToFluentCallRector::ARRAYS_TO_FLUENT_CALLS => [
+            new ArrayToFluentCall(ConfigurableClass::class, [
+                'name' => 'setName',
+                'size' => 'setSize',
+            ]),
+        ],
+        ArrayToFluentCallRector::FACTORY_METHODS => [
+            new FactoryMethod(FactoryClass::class, 'buildClass', ConfigurableClass::class, 2),
+        ],
+    ]);
+};

--- a/tests/Rector/MethodCall/ModalToGetSetRector/Fixture/fixture.php.inc
+++ b/tests/Rector/MethodCall/ModalToGetSetRector/Fixture/fixture.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\ModalToGetSetRector\Fixture;
+
+use Rector\CakePHP\Tests\Rector\MethodCall\ModalToGetSetRector\Source;
+
+class Fixture
+{
+    function run()
+    {
+        $object = new Source\SomeModelType;
+
+        $config = $object->config();
+        $config = $object->config('key');
+        $object->config('key', 'value');
+        $object->config(['key' => 'value']);
+        $object->config('key');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\ModalToGetSetRector\Fixture;
+
+use Rector\CakePHP\Tests\Rector\MethodCall\ModalToGetSetRector\Source;
+
+class Fixture
+{
+    function run()
+    {
+        $object = new Source\SomeModelType;
+
+        $config = $object->getConfig();
+        $config = $object->getConfig('key');
+        $object->setConfig('key', 'value');
+        $object->setConfig(['key' => 'value']);
+        $object->getConfig('key');
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/ModalToGetSetRector/Fixture/fixture2.php.inc
+++ b/tests/Rector/MethodCall/ModalToGetSetRector/Fixture/fixture2.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\ModalToGetSetRector\Fixture;
+
+use Rector\CakePHP\Tests\Rector\MethodCall\ModalToGetSetRector\Source;
+
+function modalToGetSet2()
+{
+    $object = new Source\SomeModelType;
+
+    $config = $object->customMethod();
+    $config = $object->customMethod('key');
+
+    $object->customMethod('key', 'value');
+    $object->customMethod(['key' => 'value']);
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\ModalToGetSetRector\Fixture;
+
+use Rector\CakePHP\Tests\Rector\MethodCall\ModalToGetSetRector\Source;
+
+function modalToGetSet2()
+{
+    $object = new Source\SomeModelType;
+
+    $config = $object->customMethodGetName();
+    $config = $object->customMethodGetName('key');
+
+    $object->customMethodSetName('key', 'value');
+    $object->customMethodSetName(['key' => 'value']);
+}
+
+?>

--- a/tests/Rector/MethodCall/ModalToGetSetRector/Fixture/fixture3.php.inc
+++ b/tests/Rector/MethodCall/ModalToGetSetRector/Fixture/fixture3.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\ModalToGetSetRector\Fixture;
+
+use Rector\CakePHP\Tests\Rector\MethodCall\ModalToGetSetRector\Source;
+
+function modalToGetSet3()
+{
+    $object = new Source\SomeModelType;
+
+    $config = $object->method();
+    $config = $object->method('key');
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\ModalToGetSetRector\Fixture;
+
+use Rector\CakePHP\Tests\Rector\MethodCall\ModalToGetSetRector\Source;
+
+function modalToGetSet3()
+{
+    $object = new Source\SomeModelType;
+
+    $config = $object->getMethod();
+    $config = $object->setMethod('key');
+}
+
+?>

--- a/tests/Rector/MethodCall/ModalToGetSetRector/Fixture/fixture4.php.inc
+++ b/tests/Rector/MethodCall/ModalToGetSetRector/Fixture/fixture4.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\ModalToGetSetRector\Fixture;
+
+use Rector\CakePHP\Tests\Rector\MethodCall\ModalToGetSetRector\Source;
+
+function modalToGetSet4()
+{
+    $object = new Source\SomeModelType;
+
+    $object->makeEntity();
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\ModalToGetSetRector\Fixture;
+
+use Rector\CakePHP\Tests\Rector\MethodCall\ModalToGetSetRector\Source;
+
+function modalToGetSet4()
+{
+    $object = new Source\SomeModelType;
+
+    $object->createEntity();
+}
+
+?>

--- a/tests/Rector/MethodCall/ModalToGetSetRector/ModalToGetSetRectorTest.php
+++ b/tests/Rector/MethodCall/ModalToGetSetRector/ModalToGetSetRectorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\ModalToGetSetRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ModalToGetSetRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/MethodCall/ModalToGetSetRector/Source/Entity.php
+++ b/tests/Rector/MethodCall/ModalToGetSetRector/Source/Entity.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\ModalToGetSetRector\Source;
+
+class Entity
+{
+}

--- a/tests/Rector/MethodCall/ModalToGetSetRector/Source/SomeModelType.php
+++ b/tests/Rector/MethodCall/ModalToGetSetRector/Source/SomeModelType.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\ModalToGetSetRector\Source;
+
+final class SomeModelType
+{
+    public function makeEntity(): Entity
+    {
+    }
+}

--- a/tests/Rector/MethodCall/ModalToGetSetRector/config/configured_rule.php
+++ b/tests/Rector/MethodCall/ModalToGetSetRector/config/configured_rule.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CakePHP\Rector\MethodCall\ModalToGetSetRector;
+
+use Rector\CakePHP\Tests\Rector\MethodCall\ModalToGetSetRector\Source\SomeModelType;
+use Rector\CakePHP\ValueObject\ModalToGetSet;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->ruleWithConfiguration(ModalToGetSetRector::class, [
+
+        new ModalToGetSet(SomeModelType::class, 'config', null, null, 2, 'array'),
+        new ModalToGetSet(
+            SomeModelType::class,
+            'customMethod',
+            'customMethodGetName',
+            'customMethodSetName',
+            2,
+            'array'
+        ),
+        new ModalToGetSet(SomeModelType::class, 'makeEntity', 'createEntity', 'generateEntity'),
+        new ModalToGetSet(SomeModelType::class, 'method'),
+
+    ]);
+};

--- a/tests/Rector/MethodCall/RemoveIntermediaryMethodRector/Fixture/fixture.php.inc
+++ b/tests/Rector/MethodCall/RemoveIntermediaryMethodRector/Fixture/fixture.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\ModalToGetSetRector\Fixture;
+
+class Fixture
+{
+    function run()
+    {
+        $this->regularMethod('call');
+        $this->getTableLocator()->otherMethod();
+        $this->Users = $this->getTableLocator()->get('Users');
+        $articles = $this->getTableLocator()->get('Articles', ['table' => 'alt_articles']);
+        $comments = $this->getTableLocator()
+            ->get('Comments');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\ModalToGetSetRector\Fixture;
+
+class Fixture
+{
+    function run()
+    {
+        $this->regularMethod('call');
+        $this->getTableLocator()->otherMethod();
+        $this->Users = $this->fetchTable('Users');
+        $articles = $this->fetchTable('Articles', ['table' => 'alt_articles']);
+        $comments = $this->fetchTable('Comments');
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/RemoveIntermediaryMethodRector/RemoveIntermediaryMethodRectorTest.php
+++ b/tests/Rector/MethodCall/RemoveIntermediaryMethodRector/RemoveIntermediaryMethodRectorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\RemoveIntermediaryMethodRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveIntermediaryMethodRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/MethodCall/RemoveIntermediaryMethodRector/config/configured_rule.php
+++ b/tests/Rector/MethodCall/RemoveIntermediaryMethodRector/config/configured_rule.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CakePHP\Rector\MethodCall\RemoveIntermediaryMethodRector;
+
+use Rector\CakePHP\ValueObject\RemoveIntermediaryMethod;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->ruleWithConfiguration(
+        RemoveIntermediaryMethodRector::class,
+        [new RemoveIntermediaryMethod('getTableLocator', 'get', 'fetchTable')]
+    );
+};

--- a/tests/Rector/MethodCall/RenameMethodCallBasedOnParameterRector/Fixture/fixture.php.inc
+++ b/tests/Rector/MethodCall/RenameMethodCallBasedOnParameterRector/Fixture/fixture.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\RenameMethodCallBasedOnParameterRector\Fixture;
+
+use Rector\CakePHP\Tests\Rector\MethodCall\RenameMethodCallBasedOnParameterRector\Source;
+
+function renameMethodCallBasedOnParameter()
+{
+    $object = new Source\SomeModelType;
+
+    $config = $object->getParam('paging');
+    $object->withParam('paging', 'value');
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\RenameMethodCallBasedOnParameterRector\Fixture;
+
+use Rector\CakePHP\Tests\Rector\MethodCall\RenameMethodCallBasedOnParameterRector\Source;
+
+function renameMethodCallBasedOnParameter()
+{
+    $object = new Source\SomeModelType;
+
+    $config = $object->getAttribute('paging');
+    $object->withAttribute('paging', 'value');
+}
+
+?>

--- a/tests/Rector/MethodCall/RenameMethodCallBasedOnParameterRector/Fixture/skip_fixture2.php.inc
+++ b/tests/Rector/MethodCall/RenameMethodCallBasedOnParameterRector/Fixture/skip_fixture2.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\RenameMethodCallBasedOnParameterRector\Fixture;
+
+use Rector\CakePHP\Tests\Rector\MethodCall\RenameMethodCallBasedOnParameterRector\Source;
+
+function renameMethodCallBasedOnParameterNoop()
+{
+    $object = new Source\SomeModelType;
+
+    $config = $object->getParam($value);
+    $config = $object->getParam('other');
+    $object->withParam('other', 'value');
+}

--- a/tests/Rector/MethodCall/RenameMethodCallBasedOnParameterRector/RenameMethodCallBasedOnParameterRectorTest.php
+++ b/tests/Rector/MethodCall/RenameMethodCallBasedOnParameterRector/RenameMethodCallBasedOnParameterRectorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\RenameMethodCallBasedOnParameterRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RenameMethodCallBasedOnParameterRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/MethodCall/RenameMethodCallBasedOnParameterRector/Source/SomeModelType.php
+++ b/tests/Rector/MethodCall/RenameMethodCallBasedOnParameterRector/Source/SomeModelType.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\RenameMethodCallBasedOnParameterRector\Source;
+
+final class SomeModelType
+{
+
+}

--- a/tests/Rector/MethodCall/RenameMethodCallBasedOnParameterRector/config/configured_rule.php
+++ b/tests/Rector/MethodCall/RenameMethodCallBasedOnParameterRector/config/configured_rule.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CakePHP\Rector\MethodCall\RenameMethodCallBasedOnParameterRector;
+
+use Rector\CakePHP\Tests\Rector\MethodCall\RenameMethodCallBasedOnParameterRector\Source\SomeModelType;
+use Rector\CakePHP\ValueObject\RenameMethodCallBasedOnParameter;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->ruleWithConfiguration(RenameMethodCallBasedOnParameterRector::class, [
+        new RenameMethodCallBasedOnParameter(SomeModelType::class, 'getParam', 'paging', 'getAttribute'),
+        new RenameMethodCallBasedOnParameter(SomeModelType::class, 'withParam', 'paging', 'withAttribute'),
+    ]);
+};

--- a/tests/Rector/Namespace_/AppUsesStaticCallToUseStatementRector/AppUsesStaticCallToUseStatementRectorTest.php
+++ b/tests/Rector/Namespace_/AppUsesStaticCallToUseStatementRector/AppUsesStaticCallToUseStatementRectorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CakePHP\Tests\Rector\Namespace_\AppUsesStaticCallToUseStatementRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AppUsesStaticCallToUseStatementRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/Namespace_/AppUsesStaticCallToUseStatementRector/Fixture/cakephp_controller.php.inc
+++ b/tests/Rector/Namespace_/AppUsesStaticCallToUseStatementRector/Fixture/cakephp_controller.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\Namespace_\AppUsesStaticCallToUseStatementRector\Fixture;
+
+\App::uses('Component', 'Controller');
+
+class CakeController
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\Namespace_\AppUsesStaticCallToUseStatementRector\Fixture;
+
+use Cake\Controller\Component;
+
+class CakeController
+{
+}
+
+?>

--- a/tests/Rector/Namespace_/AppUsesStaticCallToUseStatementRector/Fixture/cakephp_controller_with_strict_types.php.inc
+++ b/tests/Rector/Namespace_/AppUsesStaticCallToUseStatementRector/Fixture/cakephp_controller_with_strict_types.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CakePHP\Tests\Rector\Namespace_\AppUsesStaticCallToUseStatementRector\Fixture;
+
+\App::uses('Component', 'Controller');
+
+class CakeControllerWithStrictTypes
+{
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CakePHP\Tests\Rector\Namespace_\AppUsesStaticCallToUseStatementRector\Fixture;
+
+use Cake\Controller\Component;
+
+class CakeControllerWithStrictTypes
+{
+}
+
+?>

--- a/tests/Rector/Namespace_/AppUsesStaticCallToUseStatementRector/Fixture/cakephp_fixture.php.inc
+++ b/tests/Rector/Namespace_/AppUsesStaticCallToUseStatementRector/Fixture/cakephp_fixture.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\Namespace_\AppUsesStaticCallToUseStatementRector\Fixture;
+
+\App::uses('HttpSocket', 'Network/Http');
+\App::uses('Xml', 'Utility');
+\App::uses('Component', 'Controller');
+\App::uses('SomeLib', 'Data.Lib');
+\App::uses('CurrencyLib', 'PluginName.Lib/Currency');
+\App::uses('FooShell', 'MyPlugin.Console/Command');
+
+// https://github.com/cakephp/upgrade/blob/05d85c147bb1302b576b818cabb66a40462aaed0/tests/test_files/AppUsesAfter.php
+class CakePhpFixture
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\Namespace_\AppUsesStaticCallToUseStatementRector\Fixture;
+
+use App\Network\Http\HttpSocket;
+use Utility\Xml;
+use Cake\Controller\Component;
+use Data\Lib\SomeLib;
+use PluginName\Currency\CurrencyLib;
+use MyPlugin\Console\Command\FooShell;
+
+// https://github.com/cakephp/upgrade/blob/05d85c147bb1302b576b818cabb66a40462aaed0/tests/test_files/AppUsesAfter.php
+class CakePhpFixture
+{
+}
+
+?>

--- a/tests/Rector/Namespace_/AppUsesStaticCallToUseStatementRector/Fixture/cakephp_fixture.php.inc
+++ b/tests/Rector/Namespace_/AppUsesStaticCallToUseStatementRector/Fixture/cakephp_fixture.php.inc
@@ -21,7 +21,7 @@ class CakePhpFixture
 namespace Rector\CakePHP\Tests\Rector\Namespace_\AppUsesStaticCallToUseStatementRector\Fixture;
 
 use App\Network\Http\HttpSocket;
-use Utility\Xml;
+use Cake\Utility\Xml;
 use Cake\Controller\Component;
 use Data\Lib\SomeLib;
 use PluginName\Currency\CurrencyLib;

--- a/tests/Rector/Namespace_/AppUsesStaticCallToUseStatementRector/Fixture/cakephp_import_namespaces_up.php.inc
+++ b/tests/Rector/Namespace_/AppUsesStaticCallToUseStatementRector/Fixture/cakephp_import_namespaces_up.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\Namespace_\AppUsesStaticCallToUseStatementRector\Fixture;
+
+class ImportNamespacesUp
+{
+    public function test()
+    {
+        \App::uses('HtmlDomLib', 'Foo.Lib');
+        $HtmlDom = new HtmlDomLib();
+        \App::uses('HtmlDomLibExt', 'Foo.Lib');
+        $HtmlDom = new HtmlDomLibExt();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\Namespace_\AppUsesStaticCallToUseStatementRector\Fixture;
+
+use Foo\Lib\HtmlDomLib;
+use Foo\Lib\HtmlDomLibExt;
+class ImportNamespacesUp
+{
+    public function test()
+    {
+        $HtmlDom = new HtmlDomLib();
+        $HtmlDom = new HtmlDomLibExt();
+    }
+}
+
+?>

--- a/tests/Rector/Namespace_/AppUsesStaticCallToUseStatementRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Namespace_/AppUsesStaticCallToUseStatementRector/Fixture/fixture.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\Namespace_\AppUsesStaticCallToUseStatementRector\Fixture;
+
+\App::uses('NotificationListener', 'Event');
+
+class SomeClass
+{
+    public function run()
+    {
+        $values = new NotificationListener();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\Namespace_\AppUsesStaticCallToUseStatementRector\Fixture;
+
+use Event\NotificationListener;
+
+class SomeClass
+{
+    public function run()
+    {
+        $values = new NotificationListener();
+    }
+}
+
+?>

--- a/tests/Rector/Namespace_/AppUsesStaticCallToUseStatementRector/Fixture/without_namespace.php.inc
+++ b/tests/Rector/Namespace_/AppUsesStaticCallToUseStatementRector/Fixture/without_namespace.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+\App::uses('NotificationListener', 'Event');
+
+class WithoutNamespace
+{
+    public function run()
+    {
+        $values = new NotificationListener();
+    }
+}
+
+?>
+-----
+<?php
+
+use Event\NotificationListener;
+
+class WithoutNamespace
+{
+    public function run()
+    {
+        $values = new NotificationListener();
+    }
+}
+
+?>

--- a/tests/Rector/Namespace_/AppUsesStaticCallToUseStatementRector/Fixture/without_namespace_with_strict_types.php.inc
+++ b/tests/Rector/Namespace_/AppUsesStaticCallToUseStatementRector/Fixture/without_namespace_with_strict_types.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+\App::uses('NotificationListener', 'Event');
+
+class WithoutNamespaceWithStrictTypes
+{
+    public function run()
+    {
+        $values = new NotificationListener();
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+use Event\NotificationListener;
+
+class WithoutNamespaceWithStrictTypes
+{
+    public function run()
+    {
+        $values = new NotificationListener();
+    }
+}
+
+?>

--- a/tests/Rector/Namespace_/AppUsesStaticCallToUseStatementRector/Source/App.php
+++ b/tests/Rector/Namespace_/AppUsesStaticCallToUseStatementRector/Source/App.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+// faking cake php App class
+// see https://github.com/cakephp/cakephp/blob/2.4.1/lib/Cake/Core/App.php#L521
+
+final class App
+{
+    public static function uses($className, $location) {
+        // self::$_classMap[$className] = $location;
+    }
+}

--- a/tests/Rector/Namespace_/AppUsesStaticCallToUseStatementRector/Source/Xml.php
+++ b/tests/Rector/Namespace_/AppUsesStaticCallToUseStatementRector/Source/Xml.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cake\Utility;
+
+final class Xml
+{
+
+}

--- a/tests/Rector/Namespace_/AppUsesStaticCallToUseStatementRector/config/configured_rule.php
+++ b/tests/Rector/Namespace_/AppUsesStaticCallToUseStatementRector/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CakePHP\Rector\Namespace_\AppUsesStaticCallToUseStatementRector;
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(AppUsesStaticCallToUseStatementRector::class);
+};

--- a/tests/Rector/Property/ChangeSnakedFixtureNameToPascal/ChangeSnakedFixtureNameToPascalTest.php
+++ b/tests/Rector/Property/ChangeSnakedFixtureNameToPascal/ChangeSnakedFixtureNameToPascalTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CakePHP\Tests\Rector\Property\ChangeSnakedFixtureNameToPascal;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ChangeSnakedFixtureNameToPascalTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/Property/ChangeSnakedFixtureNameToPascal/Fixture/fixture.php.inc
+++ b/tests/Rector/Property/ChangeSnakedFixtureNameToPascal/Fixture/fixture.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\Property\ChangeSnakedFixtureNameToPascal\Fixture;
+
+class Fixture
+{
+    protected $fixtures = [
+        'app.users',
+        'other_app.tags',
+        'plugin.posts',
+        'plugin.messages/deleted_messages',
+    ];
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\Property\ChangeSnakedFixtureNameToPascal\Fixture;
+
+class Fixture
+{
+    protected $fixtures = [
+        'app.Users',
+        'other_app.Tags',
+        'plugin.Posts',
+        'plugin.Messages/DeletedMessages',
+    ];
+}
+
+?>

--- a/tests/Rector/Property/ChangeSnakedFixtureNameToPascal/config/configured_rule.php
+++ b/tests/Rector/Property/ChangeSnakedFixtureNameToPascal/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CakePHP\Rector\Property\ChangeSnakedFixtureNameToPascalRector;
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(ChangeSnakedFixtureNameToPascalRector::class);
+};


### PR DESCRIPTION
The RectorCakePHP is no longer exists in latest rector/rector:dev-main scoped vendor, so it moved the rules here.

Ref https://github.com/rectorphp/rector-cakephp/issues/27

