### PR TITLE
add first version of chronos 3 rector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.0', '8.1']
+        php-version: ['8.1']
         prefer-lowest: ['']
         include:
-          - php-version: '8.0'
+          - php-version: '8.1'
             prefer-lowest: 'prefer-lowest'
 
     steps:
@@ -56,19 +56,19 @@ jobs:
         fi
 
     - name: Setup problem matchers for PHPUnit
-      if: matrix.php-version == '8.0'
+      if: matrix.php-version == '8.1'
       run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
     - name: Run PHPUnit
       run: |
-        if [[ ${{ matrix.php-version }} == '8.0' ]]; then
+        if [[ ${{ matrix.php-version }} == '8.1' ]]; then
           export CODECOVERAGE=1 && vendor/bin/phpunit --verbose --coverage-clover=coverage.xml
         else
           vendor/bin/phpunit
         fi
 
     - name: Submit code coverage
-      if: matrix.php-version == '8.0'
+      if: matrix.php-version == '8.1'
       uses: codecov/codecov-action@v3
 
   cs-stan:
@@ -81,7 +81,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.0'
+        php-version: '8.1'
         extensions: mbstring, intl
         coverage: none
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 .PHONY: install-dev test check-cs
 
-DEV_DEPENDENCIES = cakephp/cakephp:^4.0 \
-  cakephp/cakephp-codesniffer:^4.0 \
+DEV_DEPENDENCIES = cakephp/cakephp:5.x-dev \
+  cakephp/cakephp-codesniffer:^5.0 \
   mikey179/vfsstream:^1.6.8 \
-  phpunit/phpunit:^9.3
+  phpunit/phpunit:^9.5
 
 install-dev:
 	composer require --dev $(DEV_DEPENDENCIES)

--- a/composer.json
+++ b/composer.json
@@ -6,14 +6,10 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
-        "cakephp/cakephp": "5.x-dev",
+        "cakephp/console": "5.x-dev",
         "nette/utils": "^3.2",
         "rector/rector": "^0.14.8",
         "symfony/string": "^6.0"
-    },
-    "require-dev": {
-        "cakephp/cakephp-codesniffer": "^5.0",
-        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {
@@ -48,5 +44,11 @@
     },
     "support": {
         "source": "https://github.com/cakephp/upgrade"
+    },
+    "require-dev": {
+        "cakephp/cakephp": "5.x-dev",
+        "cakephp/cakephp-codesniffer": "^5.0",
+        "mikey179/vfsstream": "^1.6.8",
+        "phpunit/phpunit": "^9.5"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,15 @@
     "homepage": "https://cakephp.org",
     "license": "MIT",
     "require": {
-        "php": "^8.0",
-        "cakephp/console": "^4.0",
+        "php": "^8.1",
+        "cakephp/cakephp": "5.x-dev",
         "nette/utils": "^3.2",
         "rector/rector": "^0.14.8",
         "symfony/string": "^6.0"
+    },
+    "require-dev": {
+        "cakephp/cakephp-codesniffer": "^5.0",
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {
@@ -22,6 +26,7 @@
         }
     },
     "prefer-stable": true,
+    "minimum-stability": "dev",
     "scripts": {
         "cs-check": "phpcs --colors --parallel=16 -p -s src/ tests/",
         "cs-fix": "phpcbf --colors --parallel=16 -p src/ tests/",

--- a/composer.json
+++ b/composer.json
@@ -44,11 +44,5 @@
     },
     "support": {
         "source": "https://github.com/cakephp/upgrade"
-    },
-    "require-dev": {
-        "cakephp/cakephp": "5.x-dev",
-        "cakephp/cakephp-codesniffer": "^5.0",
-        "mikey179/vfsstream": "^1.6.8",
-        "phpunit/phpunit": "^9.5"
     }
 }

--- a/config/rector/chronos3-date.php
+++ b/config/rector/chronos3-date.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+use Cake\Upgrade\Rector\Set\CakePHPSetList;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([CakePHPSetList::CHRONOS_3_DATE]);
+};

--- a/config/rector/chronos3-datetime.php
+++ b/config/rector/chronos3-datetime.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+use Cake\Upgrade\Rector\Set\CakePHPSetList;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([CakePHPSetList::CHRONOS_3_DATETIME]);
+};

--- a/config/rector/sets/chronos3-date.php
+++ b/config/rector/sets/chronos3-date.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+use Rector\Transform\Rector\MethodCall\MethodCallToAnotherMethodCallWithArgumentsRector;
+use Rector\Transform\ValueObject\MethodCallToAnotherMethodCallWithArguments;
+
+/**
+ * @see https://github.com/cakephp/chronos/blob/2.next/docs/en/2-4-upgrade-guide.rst
+ * @see https://github.com/cakephp/chronos/blob/3.x/docs/en/3-x-migration-guide.rst
+ */
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../config.php');
+
+    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
+        'Cake\Chronos\Date' => 'Cake\Chronos\ChronosDate',
+        'Cake\Chronos\MutableDate' => 'Cake\Chronos\ChronosDate',
+    ]);
+
+    $mutationMethods = [
+        'addYear' => 'addYears',
+        'subYear' => 'subYears',
+        'addYearWithOverflow' => 'addYearsWithOverflow',
+        'subYearWithOverflow' => 'subYearsWithOverflow',
+        'addMonth' => 'addMonths',
+        'subMonth' => 'subMonths',
+        'addMonthWithOverflow' => 'addMonthsWithOverflow',
+        'subMonthWithOverflow' => 'subMonthsWithOverflow',
+        'addDay' => 'addDays',
+        'subDay' => 'subDays',
+        'addWeekday' => 'addWeekdays',
+        'subWeekday' => 'subWeekdays',
+        'addWeek' => 'addWeeks',
+        'subWeek' => 'subWeeks',
+    ];
+
+    $renameMethods = [];
+
+    foreach ($mutationMethods as $oldMethod => $newMethod) {
+        $renameMethods[] = new MethodCallToAnotherMethodCallWithArguments(
+            'Cake\Chronos\ChronosDate',
+            $oldMethod,
+            $newMethod,
+            [1],
+        );
+    }
+
+    $rectorConfig->ruleWithConfiguration(
+        MethodCallToAnotherMethodCallWithArgumentsRector::class,
+        $renameMethods
+    );
+};

--- a/config/rector/sets/chronos3-datetime.php
+++ b/config/rector/sets/chronos3-datetime.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+use Rector\Transform\Rector\MethodCall\MethodCallToAnotherMethodCallWithArgumentsRector;
+use Rector\Transform\ValueObject\MethodCallToAnotherMethodCallWithArguments;
+
+/**
+ * @see https://github.com/cakephp/chronos/blob/2.next/docs/en/2-4-upgrade-guide.rst
+ * @see https://github.com/cakephp/chronos/blob/3.x/docs/en/3-x-migration-guide.rst
+ */
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../config.php');
+
+    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
+        'Cake\Chronos\MutableDateTime' => 'Cake\Chronos\Chronos',
+    ]);
+
+    $mutationMethods = [
+        'addYear' => 'addYears',
+        'subYear' => 'subYears',
+        'addYearWithOverflow' => 'addYearsWithOverflow',
+        'subYearWithOverflow' => 'subYearsWithOverflow',
+        'addMonth' => 'addMonths',
+        'subMonth' => 'subMonths',
+        'addMonthWithOverflow' => 'addMonthsWithOverflow',
+        'subMonthWithOverflow' => 'subMonthsWithOverflow',
+        'addDay' => 'addDays',
+        'subDay' => 'subDays',
+        'addWeekday' => 'addWeekdays',
+        'subWeekday' => 'subWeekdays',
+        'addWeek' => 'addWeeks',
+        'subWeek' => 'subWeeks',
+
+        // Time specific methods
+        'addHour' => 'addHours',
+        'subHour' => 'subHours',
+        'addMinute' => 'addMinutes',
+        'subMinute' => 'subMinutes',
+        'addSecond' => 'addSeconds',
+        'subSecond' => 'subSeconds',
+    ];
+
+    $renameMethods = [];
+
+    foreach ($mutationMethods as $oldMethod => $newMethod) {
+        $renameMethods[] = new MethodCallToAnotherMethodCallWithArguments(
+            'Cake\Chronos\Chronos',
+            $oldMethod,
+            $newMethod,
+            [1],
+        );
+    }
+
+    $rectorConfig->ruleWithConfiguration(
+        MethodCallToAnotherMethodCallWithArgumentsRector::class,
+        $renameMethods
+    );
+};

--- a/src/Command/FileRenameCommand.php
+++ b/src/Command/FileRenameCommand.php
@@ -38,35 +38,35 @@ class FileRenameCommand extends BaseCommand
      *
      * @var bool
      */
-    protected $git = false;
+    protected bool $git = false;
 
     /**
      * App/plugin path.
      *
      * @var string
      */
-    protected $path = '';
+    protected string $path = '';
 
     /**
      * Arguments
      *
      * @var \Cake\Console\Arguments
      */
-    protected $args;
+    protected Arguments $args;
 
     /**
      * Console IO
      *
      * @var \Cake\Console\ConsoleIo
      */
-    protected $io;
+    protected ConsoleIo $io;
 
     /**
      * Holds info of file types to move.
      *
      * @var array
      */
-    protected $types = [
+    protected array $types = [
         'templates' => [
             'regex' => '#/Template/\.$#',
             'from' => '/Template',

--- a/src/Rector/Set/CakePHPSetList.php
+++ b/src/Rector/Set/CakePHPSetList.php
@@ -65,5 +65,15 @@ final class CakePHPSetList implements SetListInterface
     /**
      * @var string
      */
+    public const CHRONOS_3_DATE = __DIR__ . '/../../../config/rector/sets/chronos3-date.php';
+
+    /**
+     * @var string
+     */
+    public const CHRONOS_3_DATETIME = __DIR__ . '/../../../config/rector/sets/chronos3-datetime.php';
+
+    /**
+     * @var string
+     */
     public const CAKEPHP_FLUENT_OPTIONS = __DIR__ . '/../../../config/rector/sets/cakephp-fluent-options.php';
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,27 +16,21 @@ declare(strict_types=1);
  */
 namespace Cake\Upgrade\Test;
 
-use Cake\Filesystem\Filesystem;
-use Cake\TestSuite\ConsoleIntegrationTestTrait;
-use Cake\TestSuite\TestCase as CakeTestCase;
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\Utility\Filesystem;
 use Cake\Utility\Hash;
+use PHPUnit\Framework\TestCase as BaseTestCase;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 
-class TestCase extends CakeTestCase
+class TestCase extends BaseTestCase
 {
     use ConsoleIntegrationTestTrait;
 
     /**
      * @var string
      */
-    protected $testAppDir;
-
-    public function setUp(): void
-    {
-        parent::setUp();
-        $this->useCommandRunner(true);
-    }
+    protected string $testAppDir;
 
     protected function setupTestApp(string $testName): void
     {

--- a/tests/TestCase/Command/RectorCommandTest.php
+++ b/tests/TestCase/Command/RectorCommandTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Upgrade\Test\TestCase\Command;
 
-use Cake\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\Upgrade\Test\TestCase;
 
 /**
@@ -40,7 +40,6 @@ class RectorCommandTest extends TestCase
     {
         parent::setUp();
 
-        $this->useCommandRunner(true);
         $this->configApplication('\Cake\Upgrade\Application', []);
     }
 
@@ -67,5 +66,19 @@ class RectorCommandTest extends TestCase
         $this->assertOutputContains('HelloCommand.php');
         $this->assertOutputContains('begin diff');
         $this->assertOutputContains('Rector applied successfully');
+    }
+
+    public function testApplyChronos3Date()
+    {
+        $this->setupTestApp(__FUNCTION__);
+        $this->exec('upgrade rector --rules chronos3-date ' . TEST_APP);
+        $this->assertTestAppUpgraded();
+    }
+
+    public function testApplyChronos3DateTime()
+    {
+        $this->setupTestApp(__FUNCTION__);
+        $this->exec('upgrade rector --rules chronos3-datetime ' . TEST_APP);
+        $this->assertTestAppUpgraded();
     }
 }

--- a/tests/test_apps/original/RectorCommand-testApplyChronos3Date/src/Chronos3.php
+++ b/tests/test_apps/original/RectorCommand-testApplyChronos3Date/src/Chronos3.php
@@ -19,7 +19,6 @@ class Chronos3 {
         $date->subWeekday();
         $date->addWeek();
         $date->subWeek();
-        $date->addWeek()->subWeek();
 
         $date = new \Cake\Chronos\MutableDate();
         $date->addYear();
@@ -36,7 +35,6 @@ class Chronos3 {
         $date->subWeekday();
         $date->addWeek();
         $date->subWeek();
-        $date->addWeek()->subWeek();
 
     }
 

--- a/tests/test_apps/original/RectorCommand-testApplyChronos3Date/src/Chronos3.php
+++ b/tests/test_apps/original/RectorCommand-testApplyChronos3Date/src/Chronos3.php
@@ -1,0 +1,43 @@
+<?php
+
+class Chronos3 {
+
+    public function date() {
+
+        $date = new \Cake\Chronos\Date();
+        $date->addYear();
+        $date->subYear();
+        $date->addYearWithOverflow();
+        $date->subYearWithOverflow();
+        $date->addMonth();
+        $date->subMonth();
+        $date->addMonthWithOverflow();
+        $date->subMonthWithOverflow();
+        $date->addDay();
+        $date->subDay();
+        $date->addWeekday();
+        $date->subWeekday();
+        $date->addWeek();
+        $date->subWeek();
+        $date->addWeek()->subWeek();
+
+        $date = new \Cake\Chronos\MutableDate();
+        $date->addYear();
+        $date->subYear();
+        $date->addYearWithOverflow();
+        $date->subYearWithOverflow();
+        $date->addMonth();
+        $date->subMonth();
+        $date->addMonthWithOverflow();
+        $date->subMonthWithOverflow();
+        $date->addDay();
+        $date->subDay();
+        $date->addWeekday();
+        $date->subWeekday();
+        $date->addWeek();
+        $date->subWeek();
+        $date->addWeek()->subWeek();
+
+    }
+
+}

--- a/tests/test_apps/original/RectorCommand-testApplyChronos3DateTime/src/Chronos3.php
+++ b/tests/test_apps/original/RectorCommand-testApplyChronos3DateTime/src/Chronos3.php
@@ -1,0 +1,33 @@
+<?php
+
+class Chronos3 {
+
+    public function datetime() {
+
+        $dateTime = new \Cake\Chronos\MutableDateTime();
+        $dateTime->addYear();
+        $dateTime->subYear();
+        $dateTime->addYearWithOverflow();
+        $dateTime->subYearWithOverflow();
+        $dateTime->addMonth();
+        $dateTime->subMonth();
+        $dateTime->addMonthWithOverflow();
+        $dateTime->subMonthWithOverflow();
+        $dateTime->addDay();
+        $dateTime->subDay();
+        $dateTime->addWeekday();
+        $dateTime->subWeekday();
+        $dateTime->addWeek();
+        $dateTime->subWeek();
+        $dateTime->addWeek()->subWeek();
+
+        $dateTime->addHour();
+        $dateTime->subHour();
+        $dateTime->addMinute();
+        $dateTime->subMinute();
+        $dateTime->addSecond();
+        $dateTime->subSecond();
+
+    }
+
+}

--- a/tests/test_apps/original/RectorCommand-testApplyChronos3DateTime/src/Chronos3.php
+++ b/tests/test_apps/original/RectorCommand-testApplyChronos3DateTime/src/Chronos3.php
@@ -19,7 +19,6 @@ class Chronos3 {
         $dateTime->subWeekday();
         $dateTime->addWeek();
         $dateTime->subWeek();
-        $dateTime->addWeek()->subWeek();
 
         $dateTime->addHour();
         $dateTime->subHour();

--- a/tests/test_apps/upgraded/RectorCommand-testApplyChronos3Date/src/Chronos3.php
+++ b/tests/test_apps/upgraded/RectorCommand-testApplyChronos3Date/src/Chronos3.php
@@ -19,7 +19,6 @@ class Chronos3 {
         $date->subWeekdays(1);
         $date->addWeeks(1);
         $date->subWeeks(1);
-        $date->addWeeks(1)->subWeeks(1);
 
         $date = new \Cake\Chronos\ChronosDate();
         $date->addYears(1);
@@ -36,7 +35,6 @@ class Chronos3 {
         $date->subWeekdays(1);
         $date->addWeeks(1);
         $date->subWeeks(1);
-        $date->addWeeks(1)->subWeeks(1);
 
     }
 

--- a/tests/test_apps/upgraded/RectorCommand-testApplyChronos3Date/src/Chronos3.php
+++ b/tests/test_apps/upgraded/RectorCommand-testApplyChronos3Date/src/Chronos3.php
@@ -1,0 +1,43 @@
+<?php
+
+class Chronos3 {
+
+    public function date() {
+
+        $date = new \Cake\Chronos\ChronosDate();
+        $date->addYears(1);
+        $date->subYears(1);
+        $date->addYearsWithOverflow(1);
+        $date->subYearsWithOverflow(1);
+        $date->addMonths(1);
+        $date->subMonths(1);
+        $date->addMonthsWithOverflow(1);
+        $date->subMonthsWithOverflow(1);
+        $date->addDays(1);
+        $date->subDays(1);
+        $date->addWeekdays(1);
+        $date->subWeekdays(1);
+        $date->addWeeks(1);
+        $date->subWeeks(1);
+        $date->addWeeks(1)->subWeeks(1);
+
+        $date = new \Cake\Chronos\ChronosDate();
+        $date->addYears(1);
+        $date->subYears(1);
+        $date->addYearsWithOverflow(1);
+        $date->subYearsWithOverflow(1);
+        $date->addMonths(1);
+        $date->subMonths(1);
+        $date->addMonthsWithOverflow(1);
+        $date->subMonthsWithOverflow(1);
+        $date->addDays(1);
+        $date->subDays(1);
+        $date->addWeekdays(1);
+        $date->subWeekdays(1);
+        $date->addWeeks(1);
+        $date->subWeeks(1);
+        $date->addWeeks(1)->subWeeks(1);
+
+    }
+
+}

--- a/tests/test_apps/upgraded/RectorCommand-testApplyChronos3DateTime/src/Chronos3.php
+++ b/tests/test_apps/upgraded/RectorCommand-testApplyChronos3DateTime/src/Chronos3.php
@@ -19,7 +19,6 @@ class Chronos3 {
         $dateTime->subWeekdays(1);
         $dateTime->addWeeks(1);
         $dateTime->subWeeks(1);
-        $dateTime->addWeeks(1)->subWeeks(1);
 
         $dateTime->addHours(1);
         $dateTime->subHours(1);

--- a/tests/test_apps/upgraded/RectorCommand-testApplyChronos3DateTime/src/Chronos3.php
+++ b/tests/test_apps/upgraded/RectorCommand-testApplyChronos3DateTime/src/Chronos3.php
@@ -1,0 +1,33 @@
+<?php
+
+class Chronos3 {
+
+    public function datetime() {
+
+        $dateTime = new \Cake\Chronos\Chronos();
+        $dateTime->addYears(1);
+        $dateTime->subYears(1);
+        $dateTime->addYearsWithOverflow(1);
+        $dateTime->subYearsWithOverflow(1);
+        $dateTime->addMonths(1);
+        $dateTime->subMonths(1);
+        $dateTime->addMonthsWithOverflow(1);
+        $dateTime->subMonthsWithOverflow(1);
+        $dateTime->addDays(1);
+        $dateTime->subDays(1);
+        $dateTime->addWeekdays(1);
+        $dateTime->subWeekdays(1);
+        $dateTime->addWeeks(1);
+        $dateTime->subWeeks(1);
+        $dateTime->addWeeks(1)->subWeeks(1);
+
+        $dateTime->addHours(1);
+        $dateTime->subHours(1);
+        $dateTime->addMinutes(1);
+        $dateTime->subMinutes(1);
+        $dateTime->addSeconds(1);
+        $dateTime->subSeconds(1);
+
+    }
+
+}


### PR DESCRIPTION
This is a first proposal for how chronos 3 rectors rules can look like.
The main part this currently adjust is the `Fewer mutation methods` mentioned in https://github.com/cakephp/chronos/blob/2.next/docs/en/2-4-upgrade-guide.rst

I added 2 separate rules for `chronos3-date` and `chronos3-datetime` since they need to be handled separately.
But maybe I don't see a way how this can easily be combined into one ruleset so help is very much appreciated 😄 

Also can someone tell my why chained method calls like
```
$dateTime->addWeek()->subWeek();
```
only get changed to this?
```
$dateTime->addWeeks(1)->subWeek();
```

As you can see in the failed tests bellow only the first method call gets refactored but not the following (or any additional chained methods)

Is this a bug in rector or is there a special setting we need to add to also apply those changes to chained method calls?

---

My main goal here is to get the base chronos class refactorings working so we only need to add our `Cake\I18n\Date` and `Cake\I18n\DateTime` classes to those respected rulesets.