### PR TITLE
Add more renames for 4.4

### DIFF
--- a/config/rector/sets/cakephp44.php
+++ b/config/rector/sets/cakephp44.php
@@ -15,6 +15,9 @@ return static function (RectorConfig $rectorConfig): void {
         'Cake\TestSuite\Stub\ConsoleOutput' => 'Cake\Console\TestSuite\StubConsoleOutput',
         'Cake\TestSuite\Stub\MissingConsoleInputException' => 'Cake\Console\TestSuite\MissingConsoleInputException',
         'Cake\TestSuite\HttpClientTrait' => 'Cake\Http\TestSuite\HttpClientTrait',
+        'Cake\Datasource\Paging\Paginator' => 'Cake\Datasource\Paging\NumericPaginator',
+        'Cake\TestSuite\ContainerStubTrait' => 'Cake\Core\TestSuite\ContainerStubTrait',
+        'Cake\TestSuite\HttpClientTrait' =>  'Cake\Http\TestSuite\HttpClientTrait',
     ]);
 
     $rectorConfig->ruleWithConfiguration(

--- a/config/rector/sets/cakephp44.php
+++ b/config/rector/sets/cakephp44.php
@@ -18,6 +18,7 @@ return static function (RectorConfig $rectorConfig): void {
         'Cake\Datasource\Paging\Paginator' => 'Cake\Datasource\Paging\NumericPaginator',
         'Cake\TestSuite\ContainerStubTrait' => 'Cake\Core\TestSuite\ContainerStubTrait',
         'Cake\TestSuite\HttpClientTrait' =>  'Cake\Http\TestSuite\HttpClientTrait',
+        'Cake\Cache\InvalidArgumentException' => 'Cake\Cache\Exception\InvalidArgumentException',
     ]);
 
     $rectorConfig->ruleWithConfiguration(


### PR DESCRIPTION
I went through the migration guide and all the deprecationWarning() we added for 4.4. There were only a few upgrades missing. The balance of the deprecation warnings aren't something I am comfortable applying automatically, or there aren't existing rectors available.