### PR TITLE
5.x Add rector to reconfigure finders to use named parameters

### DIFF
--- a/src/Rector/Rector/MethodCall/OptionsArrayToNamedParametersRector.php
+++ b/src/Rector/Rector/MethodCall/OptionsArrayToNamedParametersRector.php
@@ -1,0 +1,127 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Upgrade\Rector\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Scalar\String_;
+use Cake\Upgrade\Rector\ValueObject\OptionsArrayToNamedParameters;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Identifier;
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+use function RectorPrefix202304\dump_node;
+
+final class OptionsArrayToNamedParametersRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    public const OPTIONS_TO_NAMED_PARAMETERS = 'options_to_named_parameters';
+
+    /**
+     * @var \Cake\Upgrade\Rector\ValueObject\OptionsArrayToNamedParameters
+     */
+    private $optionsToNamed = [];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Converts trailing options arrays into named parameters. Will preserve all other arguments.', [
+            new ConfiguredCodeSample(
+                <<<'CODE_SAMPLE'
+use Cake\ORM\TableRegistry;
+
+$articles = TableRegistry::get('Articles');
+
+$query = $articles->find('list', ['field' => ['title']]);
+$query = $articles->find('all', ['conditions' => ['Articles.title' => $title]]);
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+use Cake\ORM\TableRegistry;
+
+$articles = TableRegistry::get('Articles');
+
+$query = $articles->find('list', field: ['title']]);
+$query = $articles->find('all', conditions: ['Articles.title' => $title]);
+CODE_SAMPLE
+                ,
+                [
+                    self::OPTIONS_TO_NAMED_PARAMETERS => [
+                        new OptionsArrayToNamedParameters('Table', ['find']),
+                    ],
+                ]
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<\PhpParser\Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr\MethodCall $node
+     */
+    public function configure(array $configuration): void
+    {
+        $this->optionsToNamed = $configuration[self::OPTIONS_TO_NAMED_PARAMETERS] ?? [];
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr\MethodCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        foreach ($this->optionsToNamed as $optionsToNamed) {
+            if (!$this->matchTypeAndMethodName($optionsToNamed, $node)) {
+                continue;
+            }
+            return $this->replaceMethodCall($optionsToNamed, $node);
+
+        }
+        return null;
+    }
+
+    private function matchtypeAndMethodName(OptionsArrayToNamedParameters $optionsToNamed, MethodCall $methodCall): bool
+    {
+        if (!$this->isObjectType($methodCall->var, $optionsToNamed->getObjectType())) {
+            return false;
+        }
+
+        if (in_array($methodCall->name,$optionsToNamed->getMethods(), true)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function replaceMethodCall(OptionsArrayToNamedParameters $optionsToNamed, MethodCall $methodCall): ?MethodCall
+    {
+        $argCount = count($methodCall->args);
+        // Only modify method calls that have exactly two arguments.
+        // This is important for idempotency.
+        if ($argCount !== 2) {
+            return null;
+        }
+        $optionsParam = $methodCall->args[$argCount - 1];
+        if (!$optionsParam->value instanceof Array_) {
+            return null;
+        }
+        // Create a copy of the arguments and remove the options array.
+        $argNodes = $methodCall->args;
+        unset($argNodes[$argCount - 1]);
+
+        foreach ($optionsParam->value->items as $param) {
+            $argNodes[] = new Arg($param->value, name: new Identifier($param->key->value));
+        }
+        $methodCall->args = $argNodes;
+
+        return $methodCall;
+    }
+}

--- a/src/Rector/ValueObject/OptionsArrayToNamedParameters.php
+++ b/src/Rector/ValueObject/OptionsArrayToNamedParameters.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Upgrade\Rector\ValueObject;
+
+use PHPStan\Type\ObjectType;
+
+final class OptionsArrayToNamedParameters
+{
+    public function __construct(
+        private string $class,
+        private array $methods
+    ) {
+    }
+
+    public function getClass(): string
+    {
+        return $this->class;
+    }
+
+    public function getObjectType(): ObjectType
+    {
+        return new ObjectType($this->class);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getMethods(): array
+    {
+        return $this->methods;
+    }
+}

--- a/tests/TestCase/Rector/MethodCall/OptionsArrayToNamedParametersRector/Fixture/options_to_named_parameters.php.inc
+++ b/tests/TestCase/Rector/MethodCall/OptionsArrayToNamedParametersRector/Fixture/options_to_named_parameters.php.inc
@@ -1,0 +1,62 @@
+<?php
+
+namespace Cake\Upgrade\Test\TestCase\Rector\MethodCall\OptionsArrayToNamedParametersRector\Fixture;
+
+use Cake\Upgrade\Rector\Tests\Rector\MethodCall\OptionsArrayToNamedParametersRector\Source;
+
+function optionsToNamedParameters()
+{
+    $value = 1;
+    $instance = new Source\ConfigurableClass();
+
+    $instance->find();
+    $instance->find('all');
+    $instance->find('list', ['fields' => ['name']]);
+    $instance->find('all', [
+        'conditions' => ['Articles.id' => $value],
+        'order' => ['Articles.id' => 'asc'],
+    ]);
+
+    // Preserve named parameters should they exist.
+    $instance->find('all',
+        conditions: ['Articles.id' => $value],
+        order: ['Articles.id' => 'asc'],
+    );
+
+    // Array values are not spread
+    $options = ['conditions' => ['Articles.id' => $value]];
+    $instance->find('all', $options);
+}
+
+?>
+-----
+<?php
+
+namespace Cake\Upgrade\Test\TestCase\Rector\MethodCall\OptionsArrayToNamedParametersRector\Fixture;
+
+use Cake\Upgrade\Rector\Tests\Rector\MethodCall\OptionsArrayToNamedParametersRector\Source;
+
+function optionsToNamedParameters()
+{
+    $value = 1;
+    $instance = new Source\ConfigurableClass();
+
+    $instance->find();
+    $instance->find('all');
+    $instance->find('list', fields: ['name']);
+    $instance->find('all',
+    conditions: ['Articles.id' => $value],
+    order: ['Articles.id' => 'asc']);
+
+    // Preserve named parameters should they exist.
+    $instance->find('all',
+        conditions: ['Articles.id' => $value],
+        order: ['Articles.id' => 'asc'],
+    );
+
+    // Array values are not spread
+    $options = ['conditions' => ['Articles.id' => $value]];
+    $instance->find('all', $options);
+}
+
+?>

--- a/tests/TestCase/Rector/MethodCall/OptionsArrayToNamedParametersRector/OptionsArrayToNamedParametersRectorTest.php
+++ b/tests/TestCase/Rector/MethodCall/OptionsArrayToNamedParametersRector/OptionsArrayToNamedParametersRectorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cake\Upgrade\Test\TestCase\Rector\MethodCall\OptionsArrayToNamedParametersRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class OptionsArrayToNamedParametersRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/TestCase/Rector/MethodCall/OptionsArrayToNamedParametersRector/Source/ConfigurableClass.php
+++ b/tests/TestCase/Rector/MethodCall/OptionsArrayToNamedParametersRector/Source/ConfigurableClass.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Upgrade\Test\TestCase\Rector\MethodCall\OptionsArrayToNamedParametersRector\Source;
+
+class ConfigurableClass
+{
+}

--- a/tests/TestCase/Rector/MethodCall/OptionsArrayToNamedParametersRector/config/configured_rule.php
+++ b/tests/TestCase/Rector/MethodCall/OptionsArrayToNamedParametersRector/config/configured_rule.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Cake\Upgrade\Rector\Rector\MethodCall\OptionsArrayToNamedParametersRector;
+use Cake\Upgrade\Rector\Tests\Rector\MethodCall\OptionsArrayToNamedParametersRector\Source\ConfigurableClass;
+use Cake\Upgrade\Rector\ValueObject\OptionsArrayToNamedParameters;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../../config/rector/config.php');
+
+    $rectorConfig->ruleWithConfiguration(OptionsArrayToNamedParametersRector::class, [
+        OptionsArrayToNamedParametersRector::OPTIONS_TO_NAMED_PARAMETERS => [
+            new OptionsArrayToNamedParameters(ConfigurableClass::class, ['find'])
+        ],
+    ]);
+};


### PR DESCRIPTION
This will help people upgrade more quickly and solve deprecations faster. It should be safe to run over code that is currently using named parameters as well.

Unfortunately rector jacks up the formatting when replacing nodes. I don't have a solution to that just yet. I think our best bet is to have the upgrade command run phpcs after rector is complete.

If folks are happy with the unit test for this rector, I can get it wired up to a new rector set in a follow up pull request.