### PR TITLE
5.x: query order rename rule

### DIFF
--- a/config/rector/sets/cakephp50.php
+++ b/config/rector/sets/cakephp50.php
@@ -28,6 +28,7 @@ return static function (RectorConfig $rectorConfig): void {
         [
             new OptionsArrayToNamedParameters('Cake\ORM\Table', ['find']),
             new OptionsArrayToNamedParameters('Cake\ORM\Query', ['find']),
+            new OptionsArrayToNamedParameters('Cake\ORM\Query\SelectQuery', ['find']),
             new OptionsArrayToNamedParameters('Cake\ORM\Association', ['find']),
             new OptionsArrayToNamedParameters('Cake\ORM\Table', ['get', 'rename' => ['key' => 'cacheKey']]),
         ]

--- a/config/rector/sets/cakephp50.php
+++ b/config/rector/sets/cakephp50.php
@@ -11,7 +11,9 @@ use PHPStan\Type\NullType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\UnionType;
 use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\Rector\Name\RenameClassRector;
+use Rector\Renaming\ValueObject\MethodCallRename;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector;
 use Rector\TypeDeclaration\Rector\Property\AddPropertyTypeDeclarationRector;
 use Rector\TypeDeclaration\ValueObject\AddPropertyTypeDeclaration;
@@ -82,5 +84,11 @@ return static function (RectorConfig $rectorConfig): void {
     $intNull = new UnionType([new IntegerType(), new NullType()]);
     $rectorConfig->ruleWithConfiguration(AddReturnTypeDeclarationRector::class, [
         new AddReturnTypeDeclaration('Cake\Command\Command', 'execute', $intNull),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(RenameMethodRector::class, [
+        new MethodCallRename('Cake\Database\Query', 'order', 'orderBy'),
+        new MethodCallRename('Cake\Database\Query', 'orderAsc', 'orderByAsc'),
+        new MethodCallRename('Cake\Database\Query', 'orderDesc', 'orderByDesc'),
     ]);
 };

--- a/tests/test_apps/original/RectorCommand-testApply50/src/QueryUpgrade.php
+++ b/tests/test_apps/original/RectorCommand-testApply50/src/QueryUpgrade.php
@@ -7,7 +7,15 @@ class QueryUpgrade {
 
         /** @var \Cake\ORM\Query $query */
         $query = $articles->find('all', ['conditions' => ['Articles.slug' => 'test']]);
-        $query->find('list', ['fields' => ['id', 'title']]);
+        $query->find('list', ['fields' => ['id', 'title']])
+            ->order('id')
+            ->orderAsc('id')
+            ->orderDesc('id');
+
+        $articles->query()
+            ->order('id')
+            ->orderAsc('id')
+            ->orderDesc('id');
 
         $article = $articles->get(1, ['key' => 'cache-key', 'contain' => ['Users']]);
     }

--- a/tests/test_apps/original/RectorCommand-testApply50/src/QueryUpgrade.php
+++ b/tests/test_apps/original/RectorCommand-testApply50/src/QueryUpgrade.php
@@ -5,7 +5,6 @@ class QueryUpgrade {
     public function finders() {
         $articles = new \Cake\ORM\Table();
 
-        /** @var \Cake\ORM\Query $query */
         $query = $articles->find('all', ['conditions' => ['Articles.slug' => 'test']]);
         $query->find('list', ['fields' => ['id', 'title']])
             ->order('id')

--- a/tests/test_apps/upgraded/RectorCommand-testApply50/src/QueryUpgrade.php
+++ b/tests/test_apps/upgraded/RectorCommand-testApply50/src/QueryUpgrade.php
@@ -5,7 +5,6 @@ class QueryUpgrade {
     public function finders() {
         $articles = new \Cake\ORM\Table();
 
-        /** @var \Cake\ORM\Query $query */
         $query = $articles->find('all', conditions: ['Articles.slug' => 'test']);
         $query->find('list', fields: ['id', 'title'])
             ->orderBy('id')

--- a/tests/test_apps/upgraded/RectorCommand-testApply50/src/QueryUpgrade.php
+++ b/tests/test_apps/upgraded/RectorCommand-testApply50/src/QueryUpgrade.php
@@ -7,7 +7,15 @@ class QueryUpgrade {
 
         /** @var \Cake\ORM\Query $query */
         $query = $articles->find('all', conditions: ['Articles.slug' => 'test']);
-        $query->find('list', fields: ['id', 'title']);
+        $query->find('list', fields: ['id', 'title'])
+            ->orderBy('id')
+            ->orderByAsc('id')
+            ->orderByDesc('id');
+
+        $articles->query()
+            ->orderBy('id')
+            ->orderByAsc('id')
+            ->orderByDesc('id');
 
         $article = $articles->get(1, cacheKey: 'cache-key', contain: ['Users']);
     }


### PR DESCRIPTION
Refs: https://github.com/cakephp/upgrade/issues/232

Based on https://github.com/rectorphp/rector/blob/main/docs/rector_rules_overview.md#renamemethodrector

Unfortuantely (as can be seen by the failing tests) rector doesn't seem to understand that `->find()` also returns a `Cake\Database\Query` based object which sucks because thats probably the most common place where these are used.

But doing a `$table->query()` works for some reason...