### PR TITLE
5.x: add `RemoveMethodCallRector`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "php": "^8.1",
         "cakephp/console": "5.x-dev",
         "nette/utils": "^3.2",
-        "rector/rector": "^0.17",
+        "rector/rector": "^0.17.1",
         "symfony/string": "^6.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Cake\\Upgrade\\Test\\": "tests"
+            "Cake\\Upgrade\\Test\\TestCase\\": "tests/TestCase"
         }
     },
     "prefer-stable": true,

--- a/config/rector/sets/cakephp50.php
+++ b/config/rector/sets/cakephp50.php
@@ -2,7 +2,9 @@
 declare(strict_types=1);
 
 use Cake\Upgrade\Rector\Rector\MethodCall\OptionsArrayToNamedParametersRector;
+use Cake\Upgrade\Rector\Rector\MethodCall\RemoveMethodCallRector;
 use Cake\Upgrade\Rector\ValueObject\OptionsArrayToNamedParameters;
+use Cake\Upgrade\Rector\ValueObject\RemoveMethodCall;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\IntegerType;
@@ -97,5 +99,10 @@ return static function (RectorConfig $rectorConfig): void {
         new MethodCallRename('Cake\Database\Query', 'order', 'orderBy'),
         new MethodCallRename('Cake\Database\Query', 'orderAsc', 'orderByAsc'),
         new MethodCallRename('Cake\Database\Query', 'orderDesc', 'orderByDesc'),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(RemoveMethodCallRector::class, [
+        new RemoveMethodCall('Cake\TestSuite\TestCase', 'useCommandRunner'),
+        new RemoveMethodCall('Cake\TestSuite\TestCase', 'useHttpServer'),
     ]);
 };

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,7 +5,7 @@
 
 	<testsuites>
 		<testsuite name="Upgrade Test Cases">
-			<directory>./tests/</directory>
+			<directory>./tests/TestCase/</directory>
 		</testsuite>
 	</testsuites>
 

--- a/src/Rector/Rector/MethodCall/RemoveMethodCallRector.php
+++ b/src/Rector/Rector/MethodCall/RemoveMethodCallRector.php
@@ -1,0 +1,86 @@
+<?php
+
+declare (strict_types = 1);
+
+namespace Cake\Upgrade\Rector\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\NodeTraverser;
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\Removing\Rector\FuncCall\RemoveFuncCallRector\RemoveFuncCallRectorTest
+ */
+final class RemoveMethodCallRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    /**
+     * @var string
+     */
+    public const REMOVE_METHOD_CALL_ARGS = 'remove_method_call_args';
+
+    /**
+     * @var \Cake\Upgrade\Rector\ValueObject\RemoveMethodCall[]
+     */
+    private $callsWithRemoveMethodCallArgs = [];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Remove method call', [
+            new ConfiguredCodeSample(
+                <<<'CODE_SAMPLE'
+$obj = new SomeClass();
+$obj->methodCall1();
+$obj->methodCall2();
+CODE_SAMPLE, <<<'CODE_SAMPLE'
+$obj = new SomeClass();
+$obj->methodCall2();
+CODE_SAMPLE, ['SomeClass', 'methodCall1']
+            )
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Expression::class];
+    }
+
+    /**
+     * @param Expression $node
+     */
+    public function refactor(Node $node): ?int
+    {
+        if (! $node->expr instanceof MethodCall) {
+            return null;
+        }
+
+        foreach ($this->callsWithRemoveMethodCallArgs as $removedFunction) {
+            if (! $this->isObjectType($node->expr->var, $removedFunction->getObjectType())) {
+                continue;
+            }
+
+            if (! $this->isName($node->expr->name, $removedFunction->getMethodName())) {
+                continue;
+            }
+
+            return NodeTraverser::REMOVE_NODE;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param mixed[] $configuration
+     */
+    public function configure(array $configuration): void
+    {
+        $this->callsWithRemoveMethodCallArgs = $configuration[self::REMOVE_METHOD_CALL_ARGS] ?? $configuration;
+    }
+}

--- a/src/Rector/ValueObject/RemoveMethodCall.php
+++ b/src/Rector/ValueObject/RemoveMethodCall.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Upgrade\Rector\ValueObject;
+
+use PHPStan\Type\ObjectType;
+
+final class RemoveMethodCall
+{
+    public function __construct(
+        private string $class,
+        private string $methodName
+    ) {
+    }
+
+    public function getClass(): string
+    {
+        return $this->class;
+    }
+
+    public function getMethodName(): string
+    {
+        return $this->methodName;
+    }
+
+    public function getObjectType(): ObjectType
+    {
+        return new ObjectType($this->class);
+    }
+}

--- a/tests/TestCase/Command/FileRenameCommandTest.php
+++ b/tests/TestCase/Command/FileRenameCommandTest.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Upgrade\Test\TestCase\Command;
 
 use Cake\Core\Configure;
-use Cake\Upgrade\Test\TestCase;
+use Cake\Upgrade\Test\TestCase\TestCase;
 
 /**
  * FileRenameCommand test.

--- a/tests/TestCase/Command/RectorCommandTest.php
+++ b/tests/TestCase/Command/RectorCommandTest.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Upgrade\Test\TestCase\Command;
 
 use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
-use Cake\Upgrade\Test\TestCase;
+use Cake\Upgrade\Test\TestCase\TestCase;
 
 /**
  * RectorCommand test.

--- a/tests/TestCase/Rector/MethodCall/RemoveMethodCallArgsRector/Fixture/fixture.php.inc
+++ b/tests/TestCase/Rector/MethodCall/RemoveMethodCallArgsRector/Fixture/fixture.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Cake\Upgrade\Test\TestCase\Rector\MethodCall\AddMethodCallArgsRectorTest\Fixture;
+
+use Cake\Upgrade\Test\TestCase\Rector\MethodCall\AddMethodCallArgsRector\Source\SomeModelType;
+
+function addMethodCallArgs()
+{
+    $object = new SomeModelType();
+    $object->getAttribute('paging');
+    $object->setAttribute('paging', []);
+}
+
+?>
+-----
+<?php
+
+namespace Cake\Upgrade\Test\TestCase\Rector\MethodCall\AddMethodCallArgsRectorTest\Fixture;
+
+use Cake\Upgrade\Test\TestCase\Rector\MethodCall\AddMethodCallArgsRector\Source\SomeModelType;
+
+function addMethodCallArgs()
+{
+    $object = new SomeModelType();
+    $object->setAttribute('paging', []);
+}
+
+?>

--- a/tests/TestCase/Rector/MethodCall/RemoveMethodCallArgsRector/RemoveMethodCallArgsRectorTest.php
+++ b/tests/TestCase/Rector/MethodCall/RemoveMethodCallArgsRector/RemoveMethodCallArgsRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Upgrade\Test\TestCase\Rector\MethodCall\RemoveMethodCallArgsRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveMethodCallArgsRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/TestCase/Rector/MethodCall/RemoveMethodCallArgsRector/Source/SomeModelType.php
+++ b/tests/TestCase/Rector/MethodCall/RemoveMethodCallArgsRector/Source/SomeModelType.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Upgrade\Test\TestCase\Rector\MethodCall\AddMethodCallArgsRector\Source;
+
+final class SomeModelType
+{
+
+}

--- a/tests/TestCase/Rector/MethodCall/RemoveMethodCallArgsRector/config/configured_rule.php
+++ b/tests/TestCase/Rector/MethodCall/RemoveMethodCallArgsRector/config/configured_rule.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+use Cake\Upgrade\Rector\Rector\MethodCall\RemoveMethodCallRector;
+use Cake\Upgrade\Rector\ValueObject\RemoveMethodCall;
+use Cake\Upgrade\Test\TestCase\Rector\MethodCall\AddMethodCallArgsRector\Source\SomeModelType;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../../config/rector/config.php');
+
+    $rectorConfig->ruleWithConfiguration(RemoveMethodCallRector::class, [
+        new RemoveMethodCall(SomeModelType::class, 'getAttribute'),
+    ]);
+};

--- a/tests/TestCase/TestCase.php
+++ b/tests/TestCase/TestCase.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @since         1.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Upgrade\Test;
+namespace Cake\Upgrade\Test\TestCase;
 
 use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\Utility\Filesystem;

--- a/tests/test_apps/original/RectorCommand-testApply50/src/Plugin.php
+++ b/tests/test_apps/original/RectorCommand-testApply50/src/Plugin.php
@@ -5,9 +5,6 @@ namespace MyPlugin;
 
 use Cake\Core\BasePlugin;
 
-/**
- * Plugin for AlfredCovid
- */
 class Plugin extends BasePlugin
 {
     /**

--- a/tests/test_apps/original/RectorCommand-testApply50/src/SomeTest.php
+++ b/tests/test_apps/original/RectorCommand-testApply50/src/SomeTest.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace MyPlugin;
+
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+class SomeTest extends TestCase
+{
+    use IntegrationTestTrait;
+
+    public function testSomething()
+    {
+        $this->useCommandRunner();
+        $this->useHttpServer();
+        $this->get('/');
+    }
+}

--- a/tests/test_apps/upgraded/RectorCommand-testApply50/src/Plugin.php
+++ b/tests/test_apps/upgraded/RectorCommand-testApply50/src/Plugin.php
@@ -5,9 +5,6 @@ namespace MyPlugin;
 
 use Cake\Core\BasePlugin;
 
-/**
- * Plugin for AlfredCovid
- */
 class Plugin extends BasePlugin
 {
     /**

--- a/tests/test_apps/upgraded/RectorCommand-testApply50/src/SomeTest.php
+++ b/tests/test_apps/upgraded/RectorCommand-testApply50/src/SomeTest.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace MyPlugin;
+
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+class SomeTest extends TestCase
+{
+    use IntegrationTestTrait;
+
+    public function testSomething()
+    {
+        $this->get('/');
+    }
+}


### PR DESCRIPTION
Refs: https://github.com/cakephp/upgrade/issues/232

Had to adjust the autoloading and phpunit config to not try to autoload `tests/test_apps` otherwise we would get a duplicate class error for rectors related to TestCase classes.

Also this PR adds a new `RemoveMethodCallRector` which does exactly what it's called (hopefully without any side effects 😅 )