### PR TITLE
5.x: rector update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "php": "^8.1",
         "cakephp/console": "5.x-dev",
         "nette/utils": "^3.2",
-        "rector/rector": "^0.17.1",
+        "rector/rector": "^0.17.7",
         "symfony/string": "^6.0"
     },
     "autoload": {

--- a/config/rector/sets/cakephp37.php
+++ b/config/rector/sets/cakephp37.php
@@ -45,10 +45,10 @@ return static function (RectorConfig $rectorConfig): void {
         new PropertyFetchToMethodCall('Cake\View\View', 'helpers', 'helpers'),
     ]);
 
-    $rectorConfig->ruleWithConfiguration(MethodCallToAnotherMethodCallWithArgumentsRector::class, [
-        new MethodCallToAnotherMethodCallWithArguments('Cake\Database\Query', 'join', 'clause', ['join']),
-        new MethodCallToAnotherMethodCallWithArguments('Cake\Database\Query', 'from', 'clause', ['from']),
-    ]);
+    //$rectorConfig->ruleWithConfiguration(MethodCallToAnotherMethodCallWithArgumentsRector::class, [
+    //    new MethodCallToAnotherMethodCallWithArguments('Cake\Database\Query', 'join', 'clause', ['join']),
+    //    new MethodCallToAnotherMethodCallWithArguments('Cake\Database\Query', 'from', 'clause', ['from']),
+    //]);
 
     $rectorConfig->ruleWithConfiguration(ModalToGetSetRector::class, [
         new ModalToGetSet('Cake\Database\Connection', 'logQueries', 'isQueryLoggingEnabled', 'enableQueryLogging'),

--- a/config/rector/sets/cakephp43.php
+++ b/config/rector/sets/cakephp43.php
@@ -30,18 +30,18 @@ return static function (RectorConfig $rectorConfig): void {
         [new RemoveIntermediaryMethod('getTableLocator', 'get', 'fetchTable')]
     );
 
-    $rectorConfig->ruleWithConfiguration(MethodCallToAnotherMethodCallWithArgumentsRector::class, [
-        new MethodCallToAnotherMethodCallWithArguments(
-            'Cake\Database\DriverInterface',
-            'supportsQuoting',
-            'supports',
-            ['quote'],
-        ),
-        new MethodCallToAnotherMethodCallWithArguments(
-            'Cake\Database\DriverInterface',
-            'supportsSavepoints',
-            'supports',
-            ['savepoint']
-        ),
-    ]);
+    //$rectorConfig->ruleWithConfiguration(MethodCallToAnotherMethodCallWithArgumentsRector::class, [
+    //    new MethodCallToAnotherMethodCallWithArguments(
+    //        'Cake\Database\DriverInterface',
+    //        'supportsQuoting',
+    //        'supports',
+    //        ['quote'],
+    //    ),
+    //    new MethodCallToAnotherMethodCallWithArguments(
+    //        'Cake\Database\DriverInterface',
+    //        'supportsSavepoints',
+    //        'supports',
+    //        ['savepoint']
+    //    ),
+    //]);
 };

--- a/src/Rector/Rector/Property/ChangeSnakedFixtureNameToPascalRector.php
+++ b/src/Rector/Rector/Property/ChangeSnakedFixtureNameToPascalRector.php
@@ -7,7 +7,6 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Scalar\String_;
-use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\PropertyProperty;
 use Rector\Core\Rector\AbstractRector;
@@ -62,11 +61,6 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $classLike = $this->betterNodeFinder->findParentType($node, ClassLike::class);
-        if (! $classLike instanceof ClassLike) {
-            return null;
-        }
-
         if (! $this->isName($node, 'fixtures')) {
             return null;
         }


### PR DESCRIPTION
`findParentType()` was removed in https://github.com/rectorphp/rector/releases/tag/0.17.3

But in the end this rector rule only applies to properties which requires a class to be present (as far as I can tell, I may be wrong here)

So its easier to just remove that now non-functional check instead of replacing it with something that re-implements it.

---

There is also the problem of the removed `MethodCallToAnotherMethodCallWithArgumentsRector` in 
* `config/rector/sets/cakephp43.php` and
* `config/rector/sets/cakephp37.php`

which we already talked about in https://github.com/cakephp/upgrade/pull/235

I'll try to add this here as well

