### PR TITLE
5.x: pin rector to current working version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "php": "^8.1",
         "cakephp/console": "5.x-dev",
         "nette/utils": "^3.2",
-        "rector/rector": "^0.17.7",
+        "rector/rector": "0.17.13",
         "symfony/string": "^6.0"
     },
     "autoload": {


### PR DESCRIPTION
Since any rector update could break our upgrade tool lets just pin it to a currently working version.

I was able to successfully run (without any errors while upgrading) this version on my app including 14 private plugins
https://gist.github.com/LordSimal/a95381f7decf42a13bdf4ff638d2c78a