### PR TITLE
4.x: fix build

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,9 @@
         "php": "^8.0",
         "cakephp/console": "^4.0",
         "nette/utils": "^3.2",
-        "rector/rector": "^0.15",
+        "rector/rector": "^0.16",
         "symfony/string": "^6.0",
-        "phpstan/phpstan": "1.10.34"
+        "phpstan/phpstan": "1.10.27"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Refs: https://github.com/cakephp/upgrade/pull/252

The phpstan 1.10.28 version broke this tool due to its [BetterReflection update](https://github.com/phpstan/phpstan/releases/tag/1.10.28)

Also I wasn't able to get the 4.x version running with 0.17+ rector so staying on 0.16 should be fine for what its worth