### PR TITLE
Add more 5.x upgrades

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,11 +37,5 @@
     },
     "support": {
         "source": "https://github.com/cakephp/upgrade"
-    },
-    "require-dev": {
-        "cakephp/cakephp": "5.x-dev",
-        "cakephp/cakephp-codesniffer": "^5.0",
-        "mikey179/vfsstream": "^1.6.8",
-        "phpunit/phpunit": "^10.1"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -37,5 +37,11 @@
     },
     "support": {
         "source": "https://github.com/cakephp/upgrade"
+    },
+    "require-dev": {
+        "cakephp/cakephp": "5.x-dev",
+        "cakephp/cakephp-codesniffer": "^5.0",
+        "mikey179/vfsstream": "^1.6.8",
+        "phpunit/phpunit": "^10.1"
     }
 }

--- a/config/rector/sets/cakephp50.php
+++ b/config/rector/sets/cakephp50.php
@@ -78,6 +78,7 @@ return static function (RectorConfig $rectorConfig): void {
             new AddPropertyTypeDeclaration('Cake\Controller\Controller', 'defaultTable', $stringNull),
 
             // Component properties
+            new AddPropertyTypeDeclaration('Cake\Controller\Component', '_defaultConfig', $arrayType),
             new AddPropertyTypeDeclaration('Cake\Controller\Component', 'components', $arrayType),
 
             // View properties
@@ -88,6 +89,9 @@ return static function (RectorConfig $rectorConfig): void {
             new AddPropertyTypeDeclaration('Cake\TestSuite\Fixture\TestFixture', 'connection', $stringType),
             new AddPropertyTypeDeclaration('Cake\TestSuite\Fixture\TestFixture', 'table', $stringType),
             new AddPropertyTypeDeclaration('Cake\TestSuite\Fixture\TestFixture', 'records', $arrayType),
+
+            // Cell properties
+            new AddPropertyTypeDeclaration('Cake\View\Cell', '_validCellOptions', $arrayType),
         ]
     );
 

--- a/config/rector/sets/cakephp50.php
+++ b/config/rector/sets/cakephp50.php
@@ -92,17 +92,15 @@ return static function (RectorConfig $rectorConfig): void {
 
             // Cell properties
             new AddPropertyTypeDeclaration('Cake\View\Cell', '_validCellOptions', $arrayType),
+
+            // Mailer
+            new AddPropertyTypeDeclaration('Cake\Mailer\Mailer', 'name', $stringType),
         ]
     );
 
     $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
         'Cake\I18n\FrozenDate' => 'Cake\I18n\Date',
         'Cake\I18n\FrozenTime' => 'Cake\I18n\DateTime',
-    ]);
-
-    $intNull = new UnionType([new IntegerType(), new NullType()]);
-    $rectorConfig->ruleWithConfiguration(AddReturnTypeDeclarationRector::class, [
-        new AddReturnTypeDeclaration('Cake\Command\Command', 'execute', $intNull),
     ]);
 
     $rectorConfig->ruleWithConfiguration(RenameMethodRector::class, [

--- a/tests/test_apps/original/RectorCommand-testApply50/src/SomeCell.php
+++ b/tests/test_apps/original/RectorCommand-testApply50/src/SomeCell.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+class SomeCell extends \Cake\View\Cell {
+    protected $_validCellOptions;
+}

--- a/tests/test_apps/original/RectorCommand-testApply50/src/SomeComponent.php
+++ b/tests/test_apps/original/RectorCommand-testApply50/src/SomeComponent.php
@@ -1,6 +1,9 @@
 <?php
 declare(strict_types=1);
 
-class SomeComponent extends \Cake\Controller\Component {
-    public $components;
+class SomeComponent extends \Cake\Controller\Component
+{
+    protected $components;
+
+    protected $_defaultConfig = [];
 }

--- a/tests/test_apps/original/RectorCommand-testApply50/src/SomeMailer.php
+++ b/tests/test_apps/original/RectorCommand-testApply50/src/SomeMailer.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+class SomeMailer extends \Cake\Mailer\Mailer {
+    public static $name;
+}

--- a/tests/test_apps/upgraded/RectorCommand-testApply50/src/CommandExecuteReturn.php
+++ b/tests/test_apps/upgraded/RectorCommand-testApply50/src/CommandExecuteReturn.php
@@ -10,7 +10,7 @@ use Cake\Console\ConsoleIo;
 
 class ExampleCommand extends Command
 {
-    public function execute(Arguments $args, ConsoleIo $io): ?int
+    public function execute(Arguments $args, ConsoleIo $io)
     {
         return self::CODE_SUCCESS;
     }

--- a/tests/test_apps/upgraded/RectorCommand-testApply50/src/SomeCell.php
+++ b/tests/test_apps/upgraded/RectorCommand-testApply50/src/SomeCell.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+class SomeCell extends \Cake\View\Cell {
+    protected array $_validCellOptions;
+}

--- a/tests/test_apps/upgraded/RectorCommand-testApply50/src/SomeComponent.php
+++ b/tests/test_apps/upgraded/RectorCommand-testApply50/src/SomeComponent.php
@@ -1,6 +1,9 @@
 <?php
 declare(strict_types=1);
 
-class SomeComponent extends \Cake\Controller\Component {
-    public array $components;
+class SomeComponent extends \Cake\Controller\Component
+{
+    protected array $components;
+
+    protected array $_defaultConfig = [];
 }

--- a/tests/test_apps/upgraded/RectorCommand-testApply50/src/SomeMailer.php
+++ b/tests/test_apps/upgraded/RectorCommand-testApply50/src/SomeMailer.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+class SomeMailer extends \Cake\Mailer\Mailer {
+    public static string $name;
+}


### PR DESCRIPTION
Removed the command rector, as it has negative side effects, tons of issues like
```
  40     PHPDoc tag @return with type int|void|null is not subtype of native type int|null.                           
  44     Method App\Command\EventnumberCommand::execute() should return int|null but return statement is missing. 
```
which wouldnt need to be there

If someone wanted this, they could add this as "strict rule" on top themselves I guess.
They should only be applied if the docblock type is `int|null`, not if it is `int|null|void`.