### PR TITLE
Symfony 7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,10 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
-        "cakephp/console": "5.x-dev",
+        "cakephp/console": "^5.0",
         "nette/utils": "^3.2",
-        "rector/rector": "0.19.0",
-        "symfony/string": "^6.0"
+        "rector/rector": "~0.19.0",
+        "symfony/string": "^6.0 || ^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <ruleset name="CakePHP Upgrade">
-    <config name="installed_paths" value="../../cakephp/cakephp-codesniffer" />
+    <config name="installed_paths" value="../../cakephp/cakephp-codesniffer"/>
 
-    <rule ref="CakePHP" />
+    <rule ref="CakePHP"/>
 
     <exclude-pattern>src/Rector</exclude-pattern>
     <exclude-pattern>tests/test_apps</exclude-pattern>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         bootstrap="./tests/bootstrap.php"
+         bootstrap="tests/bootstrap.php"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd">
 
 	<testsuites>
-		<testsuite name="Upgrade Test Cases">
-			<directory>./tests/TestCase/</directory>
+		<testsuite name="upgrade">
+			<directory>tests/TestCase/</directory>
 		</testsuite>
 	</testsuites>
 


### PR DESCRIPTION
It works, I can run cake3 upgrades to latest 3.8 successfully with proper changes.