### PR TITLE
A different approach to fix renameSubFolders bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.0', '8.1']
+        php-version: ['8.0', '8.1', '8.2', '8.3']
         prefer-lowest: ['']
         include:
           - php-version: '8.0'

--- a/src/Command/FileRenameCommand.php
+++ b/src/Command/FileRenameCommand.php
@@ -200,7 +200,7 @@ class FileRenameCommand extends BaseCommand
                 $path,
                 RecursiveDirectoryIterator::UNIX_PATHS
             );
-            $iterIter = new RecursiveIteratorIterator($dirIter);
+            $iterIter = new RecursiveIteratorIterator($dirIter, RecursiveIteratorIterator::CHILD_FIRST);
             $templateDirs = new RegexIterator(
                 $iterIter,
                 '#/' . $folder . '/\.$#',


### PR DESCRIPTION
#279

This does not work on my machine though. Maybe because PHP is 8.3.6:
```
PHPUnit 9.6.19 by Sebastian Bergmann and contributors.

E.....................                                            22 / 22 (100%)

Time: 00:19.494, Memory: 118.50 MB

There was 1 error:

1) Cake\Upgrade\Test\TestCase\Command\FileRenameCommandTest::testTemplates
UnexpectedValueException: RecursiveDirectoryIterator::__construct(/home/val/git/upgrade/tmp/test_app/templates/Element/Flash): Failed to open directory: No such file or directory

/home/val/git/upgrade/src/Command/FileRenameCommand.php:210
/home/val/git/upgrade/src/Command/FileRenameCommand.php:127
/home/val/git/upgrade/src/Command/FileRenameCommand.php:104
/home/val/git/upgrade/vendor/cakephp/cakephp/src/Console/BaseCommand.php:190
/home/val/git/upgrade/vendor/cakephp/cakephp/src/Console/CommandRunner.php:334
/home/val/git/upgrade/vendor/cakephp/cakephp/src/Console/CommandRunner.php:172
/home/val/git/upgrade/vendor/cakephp/cakephp/src/Console/TestSuite/ConsoleIntegrationTestTrait.php:106
/home/val/git/upgrade/tests/TestCase/Command/FileRenameCommandTest.php:32

ERRORS!
Tests: 22, Assertions: 34, Errors: 1.
```