### PR TITLE
add rector to transform ->group() to ->groupBy()

### DIFF
--- a/config/rector/sets/cakephp50.php
+++ b/config/rector/sets/cakephp50.php
@@ -7,7 +7,6 @@ use Cake\Upgrade\Rector\ValueObject\OptionsArrayToNamedParameters;
 use Cake\Upgrade\Rector\ValueObject\RemoveMethodCall;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BooleanType;
-use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\StringType;
@@ -16,10 +15,8 @@ use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
-use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector;
 use Rector\TypeDeclaration\Rector\Property\AddPropertyTypeDeclarationRector;
 use Rector\TypeDeclaration\ValueObject\AddPropertyTypeDeclaration;
-use Rector\TypeDeclaration\ValueObject\AddReturnTypeDeclaration;
 
 # @see https://book.cakephp.org/5/en/appendices/5-0-migration-guide.html
 return static function (RectorConfig $rectorConfig): void {
@@ -108,6 +105,8 @@ return static function (RectorConfig $rectorConfig): void {
         new MethodCallRename('Cake\Database\Query', 'order', 'orderBy'),
         new MethodCallRename('Cake\Database\Query', 'orderAsc', 'orderByAsc'),
         new MethodCallRename('Cake\Database\Query', 'orderDesc', 'orderByDesc'),
+        new MethodCallRename('Cake\Database\Query', 'group', 'groupBy'),
+        new MethodCallRename('Cake\Database\Query\SelectQuery', 'group', 'groupBy'),
     ]);
 
     $rectorConfig->ruleWithConfiguration(RemoveMethodCallRector::class, [

--- a/tests/TestCase/Command/RectorCommandTest.php
+++ b/tests/TestCase/Command/RectorCommandTest.php
@@ -61,7 +61,6 @@ class RectorCommandTest extends TestCase
     {
         $this->setupTestApp(__FUNCTION__);
         $this->exec('upgrade rector --rules cakephp40 --dry-run ' . TEST_APP);
-        debug($this->_out->messages());
 
         $this->assertExitSuccess();
         $this->assertOutputContains('HelloCommand.php');

--- a/tests/test_apps/original/RectorCommand-testApply50/src/QueryUpgrade.php
+++ b/tests/test_apps/original/RectorCommand-testApply50/src/QueryUpgrade.php
@@ -9,12 +9,14 @@ class QueryUpgrade {
         $query->find('list', ['fields' => ['id', 'title']])
             ->order('id')
             ->orderAsc('id')
-            ->orderDesc('id');
+            ->orderDesc('id')
+            ->group('id');
 
         $articles->query()
             ->order('id')
             ->orderAsc('id')
-            ->orderDesc('id');
+            ->orderDesc('id')
+            ->group('id');
 
         $article = $articles->get(1, ['key' => 'cache-key', 'contain' => ['Users']]);
     }

--- a/tests/test_apps/upgraded/RectorCommand-testApply50/src/QueryUpgrade.php
+++ b/tests/test_apps/upgraded/RectorCommand-testApply50/src/QueryUpgrade.php
@@ -9,12 +9,14 @@ class QueryUpgrade {
         $query->find('list', fields: ['id', 'title'])
             ->orderBy('id')
             ->orderByAsc('id')
-            ->orderByDesc('id');
+            ->orderByDesc('id')
+            ->groupBy('id');
 
         $articles->query()
             ->orderBy('id')
             ->orderByAsc('id')
-            ->orderByDesc('id');
+            ->orderByDesc('id')
+            ->groupBy('id');
 
         $article = $articles->get(1, cacheKey: 'cache-key', contain: ['Users']);
     }


### PR DESCRIPTION
Fixes https://github.com/cakephp/upgrade/issues/292

It didn't work if I just added the config to `Cake\Database\Query` since the current tests use current cake and therefore the SelectQuery subclass. Just made sure it should do it on the old base class as well.