### PR TITLE
Align rector classes with rest of cakephp formatting standards

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -4,7 +4,6 @@
 
     <rule ref="CakePHP"/>
 
-    <exclude-pattern>src/Rector</exclude-pattern>
     <exclude-pattern>tests/test_apps</exclude-pattern>
     <exclude-pattern>tests/TestCase/Rector</exclude-pattern>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,4 +6,20 @@
 
     <exclude-pattern>tests/test_apps</exclude-pattern>
     <exclude-pattern>tests/TestCase/Rector</exclude-pattern>
+
+    <rule ref="CakePHP.Commenting.FunctionComment.Missing">
+        <severity>0</severity>
+    </rule>
+    <rule ref="CakePHP.Commenting.FunctionComment.MissingParamTag">
+        <severity>0</severity>
+    </rule>
+    <rule ref="CakePHP.Commenting.FunctionComment.MissingReturn">
+        <severity>0</severity>
+    </rule>
+    <rule ref="CakePHP.Commenting.FunctionComment.MissingParamComment">
+        <severity>0</severity>
+    </rule>
+    <rule ref="CakePHP.Commenting.FunctionComment.MissingParamComment">
+        <severity>0</severity>
+    </rule>
 </ruleset>

--- a/src/Rector/NodeAnalyzer/FluentChainMethodCallNodeAnalyzer.php
+++ b/src/Rector/NodeAnalyzer/FluentChainMethodCallNodeAnalyzer.php
@@ -1,5 +1,5 @@
 <?php
-declare (strict_types=1);
+declare(strict_types=1);
 
 namespace Cake\Upgrade\Rector\NodeAnalyzer;
 
@@ -20,7 +20,7 @@ final class FluentChainMethodCallNodeAnalyzer
     /**
      * @api doctrine
      */
-    public function resolveRootMethodCall(MethodCall $methodCall) : ?MethodCall
+    public function resolveRootMethodCall(MethodCall $methodCall): ?MethodCall
     {
         $callerNode = $methodCall->var;
         while ($callerNode instanceof MethodCall && $callerNode->var instanceof MethodCall) {
@@ -29,17 +29,20 @@ final class FluentChainMethodCallNodeAnalyzer
         if ($callerNode instanceof MethodCall) {
             return $callerNode;
         }
+
         return null;
     }
+
     /**
      * @return \PhpParser\Node\Expr|\PhpParser\Node\Name
      */
-    public function resolveRootExpr(MethodCall $methodCall)
+    public function resolveRootExpr(MethodCall $methodCall): Expr|Name
     {
         $callerNode = $methodCall->var;
         while ($callerNode instanceof MethodCall || $callerNode instanceof StaticCall) {
             $callerNode = $callerNode instanceof StaticCall ? $callerNode->class : $callerNode->var;
         }
+
         return $callerNode;
     }
 }

--- a/src/Rector/Rector/MethodCall/AddMethodCallArgsRector.php
+++ b/src/Rector/Rector/MethodCall/AddMethodCallArgsRector.php
@@ -25,7 +25,7 @@ final class AddMethodCallArgsRector extends AbstractRector implements Configurab
     public const ADD_METHOD_CALL_ARGS = 'add_method_call_args';
 
     /**
-     * @var \Cake\Upgrade\Rector\ValueObject\AddMethodCallArgs[]
+     * @var array<\Cake\Upgrade\Rector\ValueObject\AddMethodCallArgs>
      */
     private array $callsWithAddMethodCallArgs = [];
 
@@ -97,7 +97,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param mixed[] $configuration
+     * @param array<mixed> $configuration
      */
     public function configure(array $configuration): void
     {

--- a/src/Rector/Rector/MethodCall/ArrayToFluentCallRector.php
+++ b/src/Rector/Rector/MethodCall/ArrayToFluentCallRector.php
@@ -3,13 +3,13 @@ declare(strict_types=1);
 
 namespace Cake\Upgrade\Rector\Rector\MethodCall;
 
+use Cake\Upgrade\Rector\ValueObject\ArrayItemsAndFluentClass;
+use Cake\Upgrade\Rector\ValueObject\ArrayToFluentCall;
+use Cake\Upgrade\Rector\ValueObject\FactoryMethod;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Scalar\String_;
-use Cake\Upgrade\Rector\ValueObject\ArrayItemsAndFluentClass;
-use Cake\Upgrade\Rector\ValueObject\ArrayToFluentCall;
-use Cake\Upgrade\Rector\ValueObject\FactoryMethod;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
@@ -31,12 +31,12 @@ final class ArrayToFluentCallRector extends AbstractRector implements Configurab
     public const FACTORY_METHODS = 'factory_methods';
 
     /**
-     * @var \Cake\Upgrade\Rector\ValueObject\ArrayToFluentCall[]
+     * @var array<\Cake\Upgrade\Rector\ValueObject\ArrayToFluentCall>
      */
     private array $arraysToFluentCalls = [];
 
     /**
-     * @var \Cake\Upgrade\Rector\ValueObject\FactoryMethod[]
+     * @var array<\Cake\Upgrade\Rector\ValueObject\FactoryMethod>
      */
     private array $factoryMethods = [];
 
@@ -115,7 +115,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param mixed[] $configuration
+     * @param array<mixed> $configuration
      */
     public function configure(array $configuration): void
     {

--- a/src/Rector/Rector/MethodCall/ModalToGetSetRector.php
+++ b/src/Rector/Rector/MethodCall/ModalToGetSetRector.php
@@ -3,11 +3,11 @@ declare(strict_types=1);
 
 namespace Cake\Upgrade\Rector\Rector\MethodCall;
 
+use Cake\Upgrade\Rector\ValueObject\ModalToGetSet;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Identifier;
-use Cake\Upgrade\Rector\ValueObject\ModalToGetSet;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
@@ -27,7 +27,7 @@ final class ModalToGetSetRector extends AbstractRector implements ConfigurableRe
     public const UNPREFIXED_METHODS_TO_GET_SET = 'unprefixed_methods_to_get_set';
 
     /**
-     * @var \Cake\Upgrade\Rector\ValueObject\ModalToGetSet[]
+     * @var array<\Cake\Upgrade\Rector\ValueObject\ModalToGetSet>
      */
     private array $unprefixedMethodsToGetSet = [];
 
@@ -92,7 +92,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param mixed[] $configuration
+     * @param array<mixed> $configuration
      */
     public function configure(array $configuration): void
     {

--- a/src/Rector/Rector/MethodCall/OptionsArrayToNamedParametersRector.php
+++ b/src/Rector/Rector/MethodCall/OptionsArrayToNamedParametersRector.php
@@ -3,19 +3,16 @@ declare(strict_types=1);
 
 namespace Cake\Upgrade\Rector\Rector\MethodCall;
 
+use Cake\Upgrade\Rector\ValueObject\OptionsArrayToNamedParameters;
 use PhpParser\Node;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Scalar\String_;
-use Cake\Upgrade\Rector\ValueObject\OptionsArrayToNamedParameters;
-use PhpParser\Node\Arg;
 use PhpParser\Node\Identifier;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
-
-use function RectorPrefix202304\dump_node;
 
 final class OptionsArrayToNamedParametersRector extends AbstractRector implements ConfigurableRectorInterface
 {
@@ -24,7 +21,7 @@ final class OptionsArrayToNamedParametersRector extends AbstractRector implement
     /**
      * @var \Cake\Upgrade\Rector\ValueObject\OptionsArrayToNamedParameters
      */
-    private $optionsToNamed = [];
+    private OptionsArrayToNamedParameters $optionsToNamed = [];
 
     public function getRuleDefinition(): RuleDefinition
     {
@@ -82,9 +79,10 @@ CODE_SAMPLE
             if (!$this->matchTypeAndMethodName($optionsToNamed, $node)) {
                 continue;
             }
-            return $this->replaceMethodCall($optionsToNamed, $node);
 
+            return $this->replaceMethodCall($optionsToNamed, $node);
         }
+
         return null;
     }
 

--- a/src/Rector/Rector/MethodCall/OptionsArrayToNamedParametersRector.php
+++ b/src/Rector/Rector/MethodCall/OptionsArrayToNamedParametersRector.php
@@ -19,9 +19,9 @@ final class OptionsArrayToNamedParametersRector extends AbstractRector implement
     public const OPTIONS_TO_NAMED_PARAMETERS = 'options_to_named_parameters';
 
     /**
-     * @var \Cake\Upgrade\Rector\ValueObject\OptionsArrayToNamedParameters
+     * @var array<\Cake\Upgrade\Rector\ValueObject\OptionsArrayToNamedParameters>
      */
-    private OptionsArrayToNamedParameters $optionsToNamed = [];
+    private array $optionsToNamed = [];
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Rector/Rector/MethodCall/OptionsArrayToNamedParametersRector.php
+++ b/src/Rector/Rector/MethodCall/OptionsArrayToNamedParametersRector.php
@@ -25,33 +25,36 @@ final class OptionsArrayToNamedParametersRector extends AbstractRector implement
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Converts trailing options arrays into named parameters. Will preserve all other arguments.', [
-            new ConfiguredCodeSample(
-                <<<'CODE_SAMPLE'
-use Cake\ORM\TableRegistry;
+        return new RuleDefinition(
+            'Converts trailing options arrays into named parameters. Will preserve all other arguments.',
+            [
+                new ConfiguredCodeSample(
+                    <<<'CODE_SAMPLE'
+    use Cake\ORM\TableRegistry;
 
-$articles = TableRegistry::get('Articles');
+    $articles = TableRegistry::get('Articles');
 
-$query = $articles->find('list', ['field' => ['title']]);
-$query = $articles->find('all', ['conditions' => ['Articles.title' => $title]]);
-CODE_SAMPLE
-                ,
-                <<<'CODE_SAMPLE'
-use Cake\ORM\TableRegistry;
+    $query = $articles->find('list', ['field' => ['title']]);
+    $query = $articles->find('all', ['conditions' => ['Articles.title' => $title]]);
+    CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+    use Cake\ORM\TableRegistry;
 
-$articles = TableRegistry::get('Articles');
+    $articles = TableRegistry::get('Articles');
 
-$query = $articles->find('list', field: ['title']]);
-$query = $articles->find('all', conditions: ['Articles.title' => $title]);
-CODE_SAMPLE
-                ,
-                [
+    $query = $articles->find('list', field: ['title']]);
+    $query = $articles->find('all', conditions: ['Articles.title' => $title]);
+    CODE_SAMPLE
+                    ,
                     [
-                        new OptionsArrayToNamedParameters('Table', ['find']),
-                    ],
-                ]
-            ),
-        ]);
+                        [
+                            new OptionsArrayToNamedParameters('Table', ['find']),
+                        ],
+                    ]
+                ),
+            ]
+        );
     }
 
     /**
@@ -86,8 +89,10 @@ CODE_SAMPLE
         return null;
     }
 
-    private function matchtypeAndMethodName(OptionsArrayToNamedParameters $optionsToNamed, MethodCall $methodCall): bool
-    {
+    private function matchtypeAndMethodName(
+        OptionsArrayToNamedParameters $optionsToNamed,
+        MethodCall $methodCall
+    ): bool {
         if (!$this->isObjectType($methodCall->var, $optionsToNamed->getObjectType())) {
             return false;
         }
@@ -95,8 +100,10 @@ CODE_SAMPLE
         return $methodCall->name == $optionsToNamed->getMethod();
     }
 
-    private function replaceMethodCall(OptionsArrayToNamedParameters $optionsToNamed, MethodCall $methodCall): ?MethodCall
-    {
+    private function replaceMethodCall(
+        OptionsArrayToNamedParameters $optionsToNamed,
+        MethodCall $methodCall
+    ): ?MethodCall {
         $argCount = count($methodCall->args);
         // Only modify method calls that have exactly two arguments.
         // This is important for idempotency.

--- a/src/Rector/Rector/MethodCall/RemoveIntermediaryMethodRector.php
+++ b/src/Rector/Rector/MethodCall/RemoveIntermediaryMethodRector.php
@@ -3,12 +3,12 @@ declare(strict_types=1);
 
 namespace Cake\Upgrade\Rector\Rector\MethodCall;
 
+use Cake\Upgrade\Rector\NodeAnalyzer\FluentChainMethodCallNodeAnalyzer;
+use Cake\Upgrade\Rector\ValueObject\RemoveIntermediaryMethod;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
-use Cake\Upgrade\Rector\NodeAnalyzer\FluentChainMethodCallNodeAnalyzer;
-use Cake\Upgrade\Rector\ValueObject\RemoveIntermediaryMethod;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
@@ -28,7 +28,7 @@ final class RemoveIntermediaryMethodRector extends AbstractRector implements Con
     public const REMOVE_INTERMEDIARY_METHOD = 'remove_intermediary_method';
 
     /**
-     * @var \Cake\Upgrade\Rector\ValueObject\RemoveIntermediaryMethod[]
+     * @var array<\Cake\Upgrade\Rector\ValueObject\RemoveIntermediaryMethod>
      */
     private array $removeIntermediaryMethod = [];
 
@@ -86,7 +86,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param mixed[] $configuration
+     * @param array<mixed> $configuration
      */
     public function configure(array $configuration): void
     {

--- a/src/Rector/Rector/MethodCall/RemoveMethodCallRector.php
+++ b/src/Rector/Rector/MethodCall/RemoveMethodCallRector.php
@@ -1,6 +1,5 @@
 <?php
-
-declare (strict_types = 1);
+declare(strict_types=1);
 
 namespace Cake\Upgrade\Rector\Rector\MethodCall;
 
@@ -24,9 +23,9 @@ final class RemoveMethodCallRector extends AbstractRector implements Configurabl
     public const REMOVE_METHOD_CALL_ARGS = 'remove_method_call_args';
 
     /**
-     * @var \Cake\Upgrade\Rector\ValueObject\RemoveMethodCall[]
+     * @var array<\Cake\Upgrade\Rector\ValueObject\RemoveMethodCall>
      */
-    private $callsWithRemoveMethodCallArgs = [];
+    private array $callsWithRemoveMethodCallArgs = [];
 
     public function getRuleDefinition(): RuleDefinition
     {
@@ -36,16 +35,18 @@ final class RemoveMethodCallRector extends AbstractRector implements Configurabl
 $obj = new SomeClass();
 $obj->methodCall1();
 $obj->methodCall2();
-CODE_SAMPLE, <<<'CODE_SAMPLE'
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
 $obj = new SomeClass();
 $obj->methodCall2();
-CODE_SAMPLE, ['SomeClass', 'methodCall1']
-            )
+CODE_SAMPLE,
+                ['SomeClass', 'methodCall1']
+            ),
         ]);
     }
 
     /**
-     * @return array<class-string<Node>>
+     * @return array<class-string<\PhpParser\Node>>
      */
     public function getNodeTypes(): array
     {
@@ -53,7 +54,7 @@ CODE_SAMPLE, ['SomeClass', 'methodCall1']
     }
 
     /**
-     * @param Expression $node
+     * @param \PhpParser\Node\Stmt\Expression $node
      */
     public function refactor(Node $node): ?int
     {
@@ -77,7 +78,7 @@ CODE_SAMPLE, ['SomeClass', 'methodCall1']
     }
 
     /**
-     * @param mixed[] $configuration
+     * @param array<mixed> $configuration
      */
     public function configure(array $configuration): void
     {

--- a/src/Rector/Rector/MethodCall/RenameMethodCallBasedOnParameterRector.php
+++ b/src/Rector/Rector/MethodCall/RenameMethodCallBasedOnParameterRector.php
@@ -3,10 +3,10 @@ declare(strict_types=1);
 
 namespace Cake\Upgrade\Rector\Rector\MethodCall;
 
+use Cake\Upgrade\Rector\ValueObject\RenameMethodCallBasedOnParameter;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Identifier;
-use Cake\Upgrade\Rector\ValueObject\RenameMethodCallBasedOnParameter;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\Rector\AbstractRector;
@@ -27,7 +27,7 @@ final class RenameMethodCallBasedOnParameterRector extends AbstractRector implem
     public const CALLS_WITH_PARAM_RENAMES = 'calls_with_param_renames';
 
     /**
-     * @var \Cake\Upgrade\Rector\ValueObject\RenameMethodCallBasedOnParameter[]
+     * @var array<\Cake\Upgrade\Rector\ValueObject\RenameMethodCallBasedOnParameter>
      */
     private array $callsWithParamRenames = [];
 
@@ -92,7 +92,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param mixed[] $configuration
+     * @param array<mixed> $configuration
      */
     public function configure(array $configuration): void
     {

--- a/src/Rector/Rector/MethodCall/SetSerializeToViewBuilderRector.php
+++ b/src/Rector/Rector/MethodCall/SetSerializeToViewBuilderRector.php
@@ -1,31 +1,34 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Cake\Upgrade\Rector\Rector\MethodCall;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
-use Rector\Rector\AbstractRector;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
-use Rector\Config\RectorConfig;
+use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 final class SetSerializeToViewBuilderRector extends AbstractRector implements ConfigurableRectorInterface
 {
-    public function getRuleDefinition(): RuleDefinition {
-        return new RuleDefinition('Change `$this->set(\'_serialize\', \'result\')` to `$this->viewBuilder()->setOption(\'serialize\', \'result\')`.', [
-            new ConfiguredCodeSample(
-                <<<'CODE_SAMPLE'
-$this->set('_serialize', 'result');
-CODE_SAMPLE
-                ,
-                <<<'CODE_SAMPLE'
-$this->viewBuilder()->setOption('serialize', 'result');
-CODE_SAMPLE
-            )
-        ]);
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Change `$this->set(\'_serialize\', \'result\')` to ' .
+                '`$this->viewBuilder()->setOption(\'serialize\', \'result\')`.',
+            [
+                new ConfiguredCodeSample(
+                    <<<'CODE_SAMPLE'
+    $this->set('_serialize', 'result');
+    CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+    $this->viewBuilder()->setOption('serialize', 'result');
+    CODE_SAMPLE
+                ),
+            ]
+        );
     }
 
     public function getNodeTypes(): array
@@ -35,7 +38,7 @@ CODE_SAMPLE
 
     public function refactor(Node $node): ?Node
     {
-        if(! $node instanceof MethodCall) {
+        if (! $node instanceof MethodCall) {
             return null;
         }
 
@@ -63,11 +66,8 @@ CODE_SAMPLE
         return isset($methodCall->args[0]) && $methodCall->args[0]->value->value === $firstArgumentValue;
     }
 
-    public function configure(array $configuration): void {
+    public function configure(array $configuration): void
+    {
         // No configuration options
     }
 }
-
-return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rule(SetSerializeToViewBuilderRector::class);
-};

--- a/src/Rector/Rector/MethodCall/TableRegistryLocatorRector.php
+++ b/src/Rector/Rector/MethodCall/TableRegistryLocatorRector.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Cake\Upgrade\Rector\Rector\MethodCall;
@@ -23,7 +22,7 @@ CODE_SAMPLE
                 <<<'CODE_SAMPLE'
 TableRegistry::getTableLocator()->get('something');
 CODE_SAMPLE
-            )
+            ),
         ]);
     }
 
@@ -34,7 +33,7 @@ CODE_SAMPLE
 
     public function refactor(Node $node): ?Node
     {
-        if(! $node instanceof StaticCall) {
+        if (! $node instanceof StaticCall) {
             return null;
         }
 

--- a/src/Rector/Rector/Namespace_/AppUsesStaticCallToUseStatementRector.php
+++ b/src/Rector/Rector/Namespace_/AppUsesStaticCallToUseStatementRector.php
@@ -139,7 +139,6 @@ CODE_SAMPLE
     /**
      * @return array<\PhpParser\Node\Expr\StaticCall>
      */
-
     private function collectAppUseStaticCalls(StmtsAwareInterface $node): array
     {
         /** @var array<\PhpParser\Node\Expr\StaticCall> $appUsesStaticCalls */
@@ -209,7 +208,6 @@ CODE_SAMPLE
         FileWithoutNamespace $fileWithoutNamespace,
         array $uses
     ): FileWithoutNamespace {
-        $newStmts = [];
         foreach ($fileWithoutNamespace->stmts as $key => $stmt) {
             if ($stmt instanceof Declare_) {
                 foreach ($uses as $use) {

--- a/src/Rector/Rector/Namespace_/AppUsesStaticCallToUseStatementRector.php
+++ b/src/Rector/Rector/Namespace_/AppUsesStaticCallToUseStatementRector.php
@@ -3,23 +3,23 @@ declare(strict_types=1);
 
 namespace Cake\Upgrade\Rector\Rector\Namespace_;
 
+use Cake\Upgrade\Rector\ShortClassNameResolver;
 use PhpParser\Node;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Name;
+use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Declare_;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Use_;
 use PhpParser\Node\Stmt\UseUse;
-use PHPStan\Type\ObjectType;
-use Cake\Upgrade\Rector\ShortClassNameResolver;
-use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
+use PHPStan\Type\ObjectType;
 use Rector\Contract\PhpParser\Node\StmtsAwareInterface;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\Rector\AbstractRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -66,7 +66,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param StmtsAwareInterface $node
+     * @param \Rector\Contract\PhpParser\Node\StmtsAwareInterface $node
      */
     public function refactor(Node $node): ?Node
     {
@@ -100,8 +100,8 @@ CODE_SAMPLE
     }
 
     /**
-     * @param Stmt[] $stmts
-     * @param StaticCall[] $appUsesStaticCalls
+     * @param array<\PhpParser\Node\Stmt> $stmts
+     * @param array<\PhpParser\Node\Expr\StaticCall> $appUsesStaticCalls
      */
     private function removeCallLikeStmts(StmtsAwareInterface $node, array $stmts, array $appUsesStaticCalls): void
     {
@@ -116,6 +116,7 @@ CODE_SAMPLE
 
                 if ($subNode instanceof Stmt) {
                     $currentStmt = $subNode;
+
                     return null;
                 }
 
@@ -127,19 +128,21 @@ CODE_SAMPLE
                     return null;
                 }
 
-                /** @var Stmt $currentStmt */
+                /** @var \PhpParser\Node\Stmt $currentStmt */
                 unset($node->stmts[$currentStmt->getAttribute(AttributeKey::STMT_KEY)]);
+
                 return null;
-            });
+            }
+        );
     }
 
     /**
-     * @return \PhpParser\Node\Expr\StaticCall[]
+     * @return array<\PhpParser\Node\Expr\StaticCall>
      */
 
     private function collectAppUseStaticCalls(StmtsAwareInterface $node): array
     {
-        /** @var \PhpParser\Node\Expr\StaticCall[] $appUsesStaticCalls */
+        /** @var array<\PhpParser\Node\Expr\StaticCall> $appUsesStaticCalls */
         $appUsesStaticCalls = $this->betterNodeFinder->find($node, function (Node $node): bool {
             if (! $node instanceof StaticCall) {
                 return false;
@@ -157,8 +160,8 @@ CODE_SAMPLE
     }
 
     /**
-     * @param \PhpParser\Node\Expr\StaticCall[] $staticCalls
-     * @return string[]
+     * @param array<\PhpParser\Node\Expr\StaticCall> $staticCalls
+     * @return array<string>
      */
     private function resolveNamesFromStaticCalls(array $staticCalls): array
     {
@@ -171,7 +174,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param \PhpParser\Node\Stmt\Use_[] $fileWithoutNamespace
+     * @param array<\PhpParser\Node\Stmt\Use_> $fileWithoutNamespace
      */
     private function refactorFile(FileWithoutNamespace $fileWithoutNamespace, array $uses): ?FileWithoutNamespace
     {
@@ -200,7 +203,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param \PhpParser\Node\Stmt\Use_[] $fileWithoutNamespace
+     * @param array<\PhpParser\Node\Stmt\Use_> $fileWithoutNamespace
      */
     private function refactorFileWithDeclare(
         FileWithoutNamespace $fileWithoutNamespace,

--- a/src/Rector/ShortClassNameResolver.php
+++ b/src/Rector/ShortClassNameResolver.php
@@ -6,6 +6,7 @@ namespace Cake\Upgrade\Rector;
 use Nette\Utils\Strings;
 use PHPStan\Reflection\ReflectionProvider;
 use Rector\Util\StringUtils;
+use function str_contains;
 
 /**
  * @inspired https://github.com/cakephp/upgrade/blob/756410c8b7d5aff9daec3fa1fe750a3858d422ac/src/Shell/Task/AppUsesTask.php
@@ -33,7 +34,7 @@ final class ShortClassNameResolver
     /**
      * A map of old => new for use statements that are missing
      *
-     * @var string[]
+     * @var array<string>
      */
     private const RENAME_MAP = [
         'App' => 'Cake\Core\App',
@@ -102,7 +103,7 @@ final class ShortClassNameResolver
 
         // C. is not plugin nor lib custom App class?
         if (
-            \str_contains($pseudoNamespace, '\\') && ! StringUtils::isMatch(
+            str_contains($pseudoNamespace, '\\') && ! StringUtils::isMatch(
                 $pseudoNamespace,
                 self::PLUGIN_OR_LIB_REGEX
             )

--- a/src/Rector/ValueObject/AddMethodCallArgs.php
+++ b/src/Rector/ValueObject/AddMethodCallArgs.php
@@ -12,7 +12,7 @@ final class AddMethodCallArgs
     public function __construct(
         private string $class,
         private string $methodName,
-        ...$values
+        mixed ...$values
     ) {
         $this->values = $values;
     }

--- a/src/Rector/ValueObject/ArrayItemsAndFluentClass.php
+++ b/src/Rector/ValueObject/ArrayItemsAndFluentClass.php
@@ -6,7 +6,7 @@ namespace Cake\Upgrade\Rector\ValueObject;
 final class ArrayItemsAndFluentClass
 {
     /**
-     * @param \PhpParser\Node\Expr\ArrayItem[] $arrayItems
+     * @param array<\PhpParser\Node\Expr\ArrayItem> $arrayItems
      * @param array<string, \PhpParser\Node\Expr> $fluentCalls
      */
     public function __construct(
@@ -16,7 +16,7 @@ final class ArrayItemsAndFluentClass
     }
 
     /**
-     * @return \PhpParser\Node\Expr\ArrayItem[]
+     * @return array<\PhpParser\Node\Expr\ArrayItem>
      */
     public function getArrayItems(): array
     {

--- a/src/Rector/ValueObject/OptionsArrayToNamedParameters.php
+++ b/src/Rector/ValueObject/OptionsArrayToNamedParameters.php
@@ -39,6 +39,7 @@ final class OptionsArrayToNamedParameters
         if (isset($this->methods['rename'])) {
             return $this->methods['rename'];
         }
+
         return [];
     }
 }


### PR DESCRIPTION
All mechanical changes from the modification in `phpcs.xml` and running `composer cs-fix`.