### PR TITLE
add 5.1 rector tests + connectionhelper rector

### DIFF
--- a/config/rector/sets/cakephp51.php
+++ b/config/rector/sets/cakephp51.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use Cake\Upgrade\Rector\Rector\MethodCall\StaticConnectionHelperRector;
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\String_\RenameStringRector;
 
@@ -11,4 +12,6 @@ return static function (RectorConfig $rectorConfig): void {
         // Rename the cache configuration used by translations.
         '_cake_core_' => '_cake_translations_',
     ]);
+
+    $rectorConfig->rule(StaticConnectionHelperRector::class);
 };

--- a/src/Rector/Rector/MethodCall/StaticConnectionHelperRector.php
+++ b/src/Rector/Rector/MethodCall/StaticConnectionHelperRector.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Upgrade\Rector\Rector\MethodCall;
+
+use Cake\TestSuite\ConnectionHelper;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Stmt\Expression;
+use PHPStan\Type\ObjectType;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class StaticConnectionHelperRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Transform ConnectionHelper instance method calls to static calls', [
+            new ConfiguredCodeSample(
+                <<<'CODE_SAMPLE'
+$connectionHelper = new ConnectionHelper();
+$connectionHelper->runWithoutConstraints($connection, function ($connection) {
+    $connection->execute('SELECT * FROM table');
+});
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+ConnectionHelper::runWithoutConstraints($connection, function ($connection) {
+    $connection->execute('SELECT * FROM table');
+});
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class, Assign::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if ($node instanceof Assign) {
+            if ($node->expr instanceof New_ && $this->isName($node->expr->class, 'ConnectionHelper')) {
+                // Remove the instantiation statement
+                $parent = $node->getAttribute(AttributeKey::PARENT_NODE);
+                if ($parent instanceof Expression) {
+                    $this->removeNode($parent);
+
+                    return null;
+                }
+            }
+        }
+
+        // Ensure the node is a method call on the ConnectionHelper instance
+        if (! $this->isObjectType($node->var, new ObjectType(ConnectionHelper::class))) {
+            return null;
+        }
+
+        // Replace with a static method call
+        return new StaticCall(
+            new Node\Name\FullyQualified(ConnectionHelper::class),
+            $node->name,
+            $node->args
+        );
+    }
+}

--- a/tests/TestCase/Command/RectorCommandTest.php
+++ b/tests/TestCase/Command/RectorCommandTest.php
@@ -91,4 +91,11 @@ class RectorCommandTest extends TestCase
         $this->exec('upgrade rector --rules cakephp50 ' . TEST_APP);
         $this->assertTestAppUpgraded();
     }
+
+    public function testApply51()
+    {
+        $this->setupTestApp(__FUNCTION__);
+        $this->exec('upgrade rector --rules cakephp51 ' . TEST_APP);
+        $this->assertTestAppUpgraded();
+    }
 }

--- a/tests/test_apps/original/RectorCommand-testApply51/src/SomeTest.php
+++ b/tests/test_apps/original/RectorCommand-testApply51/src/SomeTest.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace MyPlugin;
+
+use Cake\Datasource\ConnectionManager;
+use Cake\TestSuite\ConnectionHelper;
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+class SomeTest extends TestCase
+{
+    use IntegrationTestTrait;
+
+    public function testSomething()
+    {
+        $config = [
+            '_cake_core_' => [
+                'className' => 'FileEngine',
+                'prefix' => 'myapp_cake_core_',
+                'path' => 'persistent',
+                'serialize' => true,
+                'duration' => '+1 years',
+            ],
+        ];
+    }
+
+    public function testConnectionHelper()
+    {
+        $connectionHelper = new ConnectionHelper();
+        $connection = ConnectionManager::get('test');
+        $connectionHelper->runWithoutConstraints($connection, function ($connection) {
+            $connection->execute('SELECT * FROM table');
+        });
+        $connectionHelper->dropTables('test', ['table']);
+        $connectionHelper->enableQueryLogging(['test']);
+        $connectionHelper->truncateTables('test', ['table']);
+        $connectionHelper->addTestAliases();
+    }
+}

--- a/tests/test_apps/upgraded/RectorCommand-testApply51/src/SomeTest.php
+++ b/tests/test_apps/upgraded/RectorCommand-testApply51/src/SomeTest.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace MyPlugin;
+
+use Cake\Datasource\ConnectionManager;
+use Cake\TestSuite\ConnectionHelper;
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+class SomeTest extends TestCase
+{
+    use IntegrationTestTrait;
+
+    public function testSomething()
+    {
+        $config = [
+            '_cake_translations_' => [
+                'className' => 'FileEngine',
+                'prefix' => 'myapp_cake_core_',
+                'path' => 'persistent',
+                'serialize' => true,
+                'duration' => '+1 years',
+            ],
+        ];
+    }
+
+    public function testConnectionHelper()
+    {
+        $connectionHelper = new ConnectionHelper();
+        $connection = ConnectionManager::get('test');
+        \Cake\TestSuite\ConnectionHelper::runWithoutConstraints($connection, function ($connection) {
+            $connection->execute('SELECT * FROM table');
+        });
+        \Cake\TestSuite\ConnectionHelper::dropTables('test', ['table']);
+        \Cake\TestSuite\ConnectionHelper::enableQueryLogging(['test']);
+        \Cake\TestSuite\ConnectionHelper::truncateTables('test', ['table']);
+        \Cake\TestSuite\ConnectionHelper::addTestAliases();
+    }
+}


### PR DESCRIPTION
I tried getting rector to also remove the unnecessary `$connectionHelper = new ConnectionHelper();` but since the NodeRemoval tool was removed I have to learn to current recommended way of removing a node.