### PR TITLE
Add rector rules to update migration base classes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@
 DEV_DEPENDENCIES = cakephp/cakephp:5.x-dev \
   cakephp/cakephp-codesniffer:^5.0 \
   mikey179/vfsstream:^1.6.8 \
-  phpunit/phpunit:^10.5.38
+  phpunit/phpunit:^10.5.38 \
+  cakephp/migrations:^4.5.0
 
 install-dev:
 	composer require --dev $(DEV_DEPENDENCIES)

--- a/config/rector/migrations45.php
+++ b/config/rector/migrations45.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+use Cake\Upgrade\Rector\Set\CakePHPSetList;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([CakePHPSetList::MIGRATIONS_45]);
+};

--- a/config/rector/sets/migrations45.php
+++ b/config/rector/sets/migrations45.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+
+/**
+ * @see https://github.com/cakephp/migrations/releases/4.5.0/
+ */
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
+        'Migrations\AbstractMigration' => 'Migrations\BaseMigration',
+        'Migrations\AbstractSeed' => 'Migrations\BaseSeed',
+    ]);
+};

--- a/src/Rector/Set/CakePHPSetList.php
+++ b/src/Rector/Set/CakePHPSetList.php
@@ -90,5 +90,10 @@ final class CakePHPSetList implements SetListInterface
     /**
      * @var string
      */
+    public const MIGRATIONS_45 = __DIR__ . '/../../../config/rector/sets/migrations45.php';
+
+    /**
+     * @var string
+     */
     public const CAKEPHP_FLUENT_OPTIONS = __DIR__ . '/../../../config/rector/sets/cakephp-fluent-options.php';
 }

--- a/tests/TestCase/Command/RectorCommandTest.php
+++ b/tests/TestCase/Command/RectorCommandTest.php
@@ -105,4 +105,11 @@ class RectorCommandTest extends TestCase
         $this->exec('upgrade rector --rules cakephp52 ' . TEST_APP);
         $this->assertTestAppUpgraded();
     }
+
+    public function testApplyMigrations45()
+    {
+        $this->setupTestApp(__FUNCTION__);
+        $this->exec('upgrade rector --rules migrations45 ' . TEST_APP);
+        $this->assertTestAppUpgraded();
+    }
 }

--- a/tests/TestCase/TestCase.php
+++ b/tests/TestCase/TestCase.php
@@ -27,6 +27,8 @@ class TestCase extends BaseTestCase
 {
     use ConsoleIntegrationTestTrait;
 
+    public $appPluginsToLoad = [];
+
     /**
      * @var string
      */

--- a/tests/test_apps/original/RectorCommand-testApplyMigrations45/src/Migrations45.php
+++ b/tests/test_apps/original/RectorCommand-testApplyMigrations45/src/Migrations45.php
@@ -1,0 +1,13 @@
+<?php
+use Migrations\AbstractMigration;
+use Migrations\AbstractSeed;
+
+class Migrations45 extends AbstractMigration {
+    public function change() {
+    }
+}
+
+class Seed45 extends AbstractSeed {
+    public function run() {
+    }
+}

--- a/tests/test_apps/upgraded/RectorCommand-testApplyMigrations45/src/Migrations45.php
+++ b/tests/test_apps/upgraded/RectorCommand-testApplyMigrations45/src/Migrations45.php
@@ -1,0 +1,13 @@
+<?php
+use Migrations\AbstractMigration;
+use Migrations\AbstractSeed;
+
+class Migrations45 extends \Migrations\BaseMigration {
+    public function change() {
+    }
+}
+
+class Seed45 extends \Migrations\BaseSeed {
+    public function run() {
+    }
+}


### PR DESCRIPTION
Part of the work to separate migrations from phinx