### PR TITLE
Directly use ->isName() on RemoveIntermediaryMethodRector

### DIFF
--- a/src/Rector/Rector/MethodCall/RemoveIntermediaryMethodRector.php
+++ b/src/Rector/Rector/MethodCall/RemoveIntermediaryMethodRector.php
@@ -102,7 +102,7 @@ CODE_SAMPLE
         if (! $rootMethodCall->var instanceof Variable) {
             return null;
         }
-        if (! $this->nodeNameResolver->isName($rootMethodCall->var, 'this')) {
+        if (! $this->isName($rootMethodCall->var, 'this')) {
             return null;
         }
         /** @var \PhpParser\Node\Expr\MethodCall $var */


### PR DESCRIPTION
Rector is removing use of protected property `nodeNameResolver` in rules, use `isName()` directly instead. Ref PR:

- https://github.com/rectorphp/rector-src/pull/6875

