### PR TITLE
Fix  deprecated fetch constant from NodeTraverser

### DIFF
--- a/src/Rector/Rector/MethodCall/RemoveMethodCallRector.php
+++ b/src/Rector/Rector/MethodCall/RemoveMethodCallRector.php
@@ -6,7 +6,7 @@ namespace Cake\Upgrade\Rector\Rector\MethodCall;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Stmt\Expression;
-use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
@@ -71,7 +71,7 @@ CODE_SAMPLE,
                 continue;
             }
 
-            return NodeTraverser::REMOVE_NODE;
+            return NodeVisitor::REMOVE_NODE;
         }
 
         return null;

--- a/src/Rector/Rector/Namespace_/AppUsesStaticCallToUseStatementRector.php
+++ b/src/Rector/Rector/Namespace_/AppUsesStaticCallToUseStatementRector.php
@@ -12,7 +12,7 @@ use PhpParser\Node\Stmt\Declare_;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Use_;
 use PhpParser\Node\UseItem;
-use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
 use PHPStan\Type\ObjectType;
 use Rector\Contract\PhpParser\Node\StmtsAwareInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -111,7 +111,7 @@ CODE_SAMPLE
             function (Node $subNode) use ($node, $appUsesStaticCalls, &$currentStmt) {
                 // only lookup each of current stmts, avoid too deep traversal
                 if ($subNode instanceof StmtsAwareInterface) {
-                    return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+                    return NodeVisitor::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
                 }
 
                 if ($subNode instanceof Stmt) {


### PR DESCRIPTION
Use `NodeVisitor` instead.