### PR TITLE
Allow per-file run.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,4 +105,4 @@ jobs:
       run: make install-dev
 
     - name: Run PHP CodeSniffer
-      run: vendor/bin/phpcs --report=checkstyle src/ tests/
+      run: vendor/bin/phpcs --report=checkstyle

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,9 @@
         "symfony/process": "^6.0 || ^7.0",
         "symfony/string": "^6.0 || ^7.0"
     },
+    "require-dev": {
+        "cakephp/cakephp-codesniffer": "^5.0"
+    },
     "autoload": {
         "psr-4": {
             "Cake\\Upgrade\\": "src/"
@@ -25,6 +28,7 @@
     "prefer-stable": true,
     "minimum-stability": "dev",
     "scripts": {
+        "stan":  "phpstan analyze",
         "cs-check": "phpcs --colors --parallel=16 -p -s src/ tests/",
         "cs-fix": "phpcbf --colors --parallel=16 -p src/ tests/",
         "test": "phpunit"

--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,8 @@
     "prefer-stable": true,
     "minimum-stability": "dev",
     "scripts": {
-        "stan":  "phpstan analyze",
-        "cs-check": "phpcs --colors --parallel=16 -p -s src/ tests/",
-        "cs-fix": "phpcbf --colors --parallel=16 -p src/ tests/",
+        "cs-check": "phpcs --colors --parallel=16 -p -s",
+        "cs-fix": "phpcbf --colors --parallel=16 -p",
         "test": "phpunit"
     },
     "config": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,6 +2,9 @@
 <ruleset name="CakePHP Upgrade">
     <config name="installed_paths" value="../../cakephp/cakephp-codesniffer"/>
 
+    <file>src/</file>
+    <file>tests/</file>
+
     <rule ref="CakePHP"/>
 
     <exclude-pattern>tests/test_apps</exclude-pattern>

--- a/src/Command/RectorCommand.php
+++ b/src/Command/RectorCommand.php
@@ -20,6 +20,10 @@ use Cake\Console\Arguments;
 use Cake\Console\BaseCommand;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RegexIterator;
+use SplFileInfo;
 use Symfony\Component\Process\Process;
 
 /**
@@ -27,6 +31,8 @@ use Symfony\Component\Process\Process;
  */
 class RectorCommand extends BaseCommand
 {
+    protected const CODE_CHANGES = 2;
+
     /**
      * Execute.
      *
@@ -64,7 +70,12 @@ class RectorCommand extends BaseCommand
 
             return static::CODE_ERROR;
         }
-        $io->success('🎉 Upgrade complete! 🎉');
+
+        $success = '🎉 Upgrade complete! 🎉';
+        if ($args->getOption('dry-run')) {
+            $success .= ' [DRY-RUN]';
+        }
+        $io->success($success);
 
         return static::CODE_SUCCESS;
     }
@@ -79,37 +90,15 @@ class RectorCommand extends BaseCommand
      */
     protected function runRector(ConsoleIo $io, Arguments $args, string $autoload): bool
     {
-        $config = ROOT . '/config/rector/' . basename((string)$args->getOption('rules')) . '.php';
-        $path = realpath((string)$args->getArgument('path'));
-
-        $cmdPath = ROOT . '/vendor/bin/rector process';
-        $command = sprintf(
-            '%s %s %s --autoload-file=%s --config=%s %s --clear-cache',
-            $cmdPath,
-            $args->getOption('dry-run') ? '--dry-run' : '',
-            $args->getOption('verbose') ? '-vvvv' : '',
-            escapeshellarg($autoload),
-            escapeshellarg($config),
-            escapeshellarg($path),
-        );
-        $io->verbose("Running <info>{$command}</info>");
-
         $io->info('Starting rector at ' . date('Y-m-d H:i:s'));
 
-        $process = Process::fromShellCommandline($command);
-        $process->setEnv($_ENV);
-        $process->setTimeout(null);
-        $process->start();
-
-        foreach ($process as $type => $data) {
-            if ($type === Process::OUT) {
-                $io->out($data);
-            } elseif ($type === Process::ERR) {
-                $io->err($data);
-            }
+        if ($args->getOption('per-file')) {
+            $result = $this->processPerFile($io, $args, $autoload);
+        } else {
+            $result = $this->processDirectory($io, $args, $autoload);
         }
 
-        if (!$process->isSuccessful()) {
+        if (!$result) {
             $io->error('Something went wrong while running rector.');
 
             return false;
@@ -151,6 +140,80 @@ class RectorCommand extends BaseCommand
         return null;
     }
 
+    protected function processDirectory(ConsoleIo $io, Arguments $args, string $autoload): bool
+    {
+        $config = ROOT . '/config/rector/' . basename((string)$args->getOption('rules')) . '.php';
+        $path = realpath((string)$args->getArgument('path'));
+
+        $command = $this->buildCommand($args, $autoload, $config, $path);
+        $io->verbose("Running <info>{$command}</info>");
+
+        $process = Process::fromShellCommandline($command);
+        $process->setEnv($_ENV);
+        $process->setTimeout(null);
+        $process->start();
+
+        foreach ($process as $type => $data) {
+            if ($type === Process::OUT) {
+                $io->out($data);
+            } elseif ($type === Process::ERR) {
+                $io->err($data);
+            }
+        }
+
+        return $process->getExitCode() !== static::CODE_ERROR;
+    }
+
+    protected function processPerFile(ConsoleIo $io, Arguments $args, string $autoload): bool
+    {
+        $config = ROOT . '/config/rector/' . basename((string)$args->getOption('rules')) . '.php';
+        $path = realpath((string)$args->getArgument('path'));
+
+        if (is_file($path)) {
+            $phpFiles = [
+                new SplFileInfo($path),
+            ];
+        } else {
+            $files = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path));
+            $phpFiles = new RegexIterator($files, '/\.php|\.ctp$/');
+        }
+
+        $result = true;
+        $totalFiles = $changedFiles = 0;
+
+        /** @var \SplFileInfo $file */
+        foreach ($phpFiles as $file) {
+            $io->out('Processing ' . $file->getPathname());
+
+            $command = $this->buildCommand($args, $autoload, $config, $file->getPathname());
+            $io->verbose("Running <info>{$command}</info>");
+
+            $process = Process::fromShellCommandline($command);
+            $process->setEnv($_ENV);
+            $process->setTimeout(null);
+            $process->start();
+
+            foreach ($process as $type => $data) {
+                if ($type === Process::OUT) {
+                    $io->out($data);
+                } elseif ($type === Process::ERR) {
+                    $io->err($data);
+                }
+            }
+
+            if ($process->getExitCode() === static::CODE_ERROR) {
+                $result = false;
+            } elseif ($process->getExitCode() === static::CODE_CHANGES) {
+                $changedFiles++;
+            }
+            $totalFiles++;
+        }
+
+        $io->out("{$changedFiles}/{$totalFiles} files changed.");
+
+        return $result;
+    }
+
     /**
      * Gets the option parser instance and configures it.
      *
@@ -186,11 +249,38 @@ class RectorCommand extends BaseCommand
                 'help' => 'The path to the application/plugin autoload if one cannot be auto-detected, ' .
                     'or is detected incorrectly.',
             ])
+            ->addOption('per-file', [
+                'help' => 'Run rector on a per-file basis instead of the whole directory.',
+                'boolean' => true,
+            ])
             ->addOption('dry-run', [
                 'help' => 'Enable to get a preview of what modifications will be applied.',
                 'boolean' => true,
+                'short' => 'd',
             ]);
 
         return $parser;
+    }
+
+    /**
+     * @param \Cake\Console\Arguments $args
+     * @param string $autoload
+     * @param string $config
+     * @param string|bool $path
+     * @return string
+     */
+    protected function buildCommand(Arguments $args, string $autoload, string $config, bool|string $path): string
+    {
+        $cmdPath = ROOT . '/vendor/bin/rector process';
+
+        return sprintf(
+            '%s %s %s --autoload-file=%s --config=%s %s --clear-cache',
+            $cmdPath,
+            $args->getOption('dry-run') ? '--dry-run' : '',
+            $args->getOption('verbose') ? '-vvvv' : '',
+            escapeshellarg($autoload),
+            escapeshellarg($config),
+            escapeshellarg($path),
+        );
     }
 }

--- a/tests/TestCase/Command/RectorCommandTest.php
+++ b/tests/TestCase/Command/RectorCommandTest.php
@@ -62,7 +62,7 @@ class RectorCommandTest extends TestCase
         $this->setupTestApp(__FUNCTION__);
         $this->exec('upgrade rector --rules cakephp40 --dry-run ' . TEST_APP);
 
-        $this->assertExitError(); // --dry-run inverts the exit code
+        $this->assertExitSuccess();
         $this->assertOutputContains('HelloCommand.php');
         $this->assertOutputContains('begin diff');
     }


### PR DESCRIPTION
Resolves https://github.com/cakephp/upgrade/issues/317

Also fixes a few things:

Dry-run needs "changes" 2 code to be respected.
Now proper output here too.

Adding dry run into final message for clarity.

Added CS again to keep code clean. PHPStan doesnt run I think, so I skipped that one.

Dry-run didnt have short d option, usually always exists



So now it looks like this for --per-file

```
Starting rector at 2025-06-18 08:26:55

...

20/37 files changed.
Rector completed successfully at 2025-06-18 08:28:03
```