### PR TITLE
6.x new rectors

### DIFF
--- a/config/rector/sets/cakephp60.php
+++ b/config/rector/sets/cakephp60.php
@@ -1,6 +1,9 @@
 <?php
 declare(strict_types=1);
 
+use Cake\Upgrade\Rector\Rector\MethodCall\RequestQueryParamRector;
+use Cake\Upgrade\Rector\Rector\MethodCall\TextInsertPlaceholderRector;
+use Cake\Upgrade\Rector\Rector\String_\RenameFormHelperTemplateKeyRector;
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\Rector\PropertyFetch\RenamePropertyRector;
@@ -13,6 +16,15 @@ use Rector\TypeDeclaration\ValueObject\AddReturnTypeDeclaration;
 
 # @see https://book.cakephp.org/6/en/appendices/6-0-migration-guide.html
 return static function (RectorConfig $rectorConfig): void {
+
+    // Replace $request->getParam('?') with $request->getQueryParams()
+    $rectorConfig->rule(RequestQueryParamRector::class);
+
+    // Replace :placeholder with {placeholder} in Text::insert() calls
+    $rectorConfig->rule(TextInsertPlaceholderRector::class);
+
+    // Rename 'multicheckboxTitle' to 'multicheckboxLabel' in FormHelper templates
+    $rectorConfig->rule(RenameFormHelperTemplateKeyRector::class);
 
     // Changes related to the accessible => patchable rename
     $rectorConfig->ruleWithConfiguration(RenameMethodRector::class, [

--- a/src/Rector/Rector/MethodCall/RequestQueryParamRector.php
+++ b/src/Rector/Rector/MethodCall/RequestQueryParamRector.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Upgrade\Rector\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Type\ObjectType;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Replace $request->getParam('?') with $request->getQueryParams()
+ * for ServerRequest instances in CakePHP 6.0
+ */
+final class RequestQueryParamRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace $request->getParam(\'?\') with $request->getQueryParams()',
+            [
+                new CodeSample(
+                    '$queryParams = $request->getParam(\'?\');',
+                    '$queryParams = $request->getQueryParams();',
+                ),
+            ],
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if (!$node instanceof MethodCall) {
+            return null;
+        }
+
+        if (!$this->isName($node->name, 'getParam')) {
+            return null;
+        }
+
+        // Check if this is a ServerRequest method call
+        $objectType = $this->getType($node->var);
+        if (!$objectType instanceof ObjectType) {
+            return null;
+        }
+
+        if (!$objectType->isInstanceOf('Cake\Http\ServerRequest')->yes()) {
+            return null;
+        }
+
+        // Check if the first argument is the string '?'
+        if (count($node->args) === 0) {
+            return null;
+        }
+
+        $firstArg = $node->args[0]->value;
+        if (!$firstArg instanceof String_) {
+            return null;
+        }
+
+        if ($firstArg->value !== '?') {
+            return null;
+        }
+
+        // Replace with getQueryParams() call with no arguments
+        return new MethodCall(
+            $node->var,
+            new Identifier('getQueryParams'),
+        );
+    }
+}

--- a/src/Rector/Rector/MethodCall/TextInsertPlaceholderRector.php
+++ b/src/Rector/Rector/MethodCall/TextInsertPlaceholderRector.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Upgrade\Rector\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Scalar\String_;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Replace :placeholder with {placeholder} in Text::insert() calls
+ * for CakePHP 6.0, unless 'before' or 'after' options are explicitly set
+ */
+final class TextInsertPlaceholderRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace :placeholder with {placeholder} in Text::insert() calls',
+            [
+                new CodeSample(
+                    'Text::insert(\'Hello :name\', [\'name\' => \'World\']);',
+                    'Text::insert(\'Hello {name}\', [\'name\' => \'World\']);',
+                ),
+            ],
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [StaticCall::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if (!$node instanceof StaticCall) {
+            return null;
+        }
+
+        if (!$this->isName($node->class, 'Cake\Utility\Text')) {
+            return null;
+        }
+
+        if (!$this->isName($node->name, 'insert')) {
+            return null;
+        }
+
+        // Need at least 1 argument (the template string)
+        if (count($node->args) === 0) {
+            return null;
+        }
+
+        $templateArg = $node->args[0];
+        if (!$templateArg->value instanceof String_) {
+            return null;
+        }
+
+        // Check if 'before' or 'after' options are set in the third argument
+        if (count($node->args) >= 3) {
+            $optionsArg = $node->args[2];
+            if ($optionsArg->value instanceof Array_) {
+                if ($this->hasBeforeOrAfterOption($optionsArg->value)) {
+                    // Skip transformation if custom before/after are set
+                    return null;
+                }
+            }
+        }
+
+        // Transform the template string
+        $originalTemplate = $templateArg->value->value;
+        $transformedTemplate = $this->transformPlaceholders($originalTemplate);
+
+        // If no change, return null
+        if ($originalTemplate === $transformedTemplate) {
+            return null;
+        }
+
+        // Create new String_ node with transformed template
+        $node->args[0] = new Arg(new String_($transformedTemplate));
+
+        return $node;
+    }
+
+    /**
+     * Check if the options array has 'before' or 'after' keys
+     */
+    private function hasBeforeOrAfterOption(Array_ $array): bool
+    {
+        foreach ($array->items as $item) {
+            if ($item instanceof ArrayItem && $item->key instanceof String_) {
+                if (in_array($item->key->value, ['before', 'after'], true)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Transform :placeholder to {placeholder}
+     * Matches :word (word characters: letters, numbers, underscore)
+     */
+    private function transformPlaceholders(string $template): string
+    {
+        // Replace :word with {word}
+        // Match : followed by word characters (letters, digits, underscore)
+        return preg_replace('/:(\w+)/', '{$1}', $template);
+    }
+}

--- a/src/Rector/Rector/String_/RenameFormHelperTemplateKeyRector.php
+++ b/src/Rector/Rector/String_/RenameFormHelperTemplateKeyRector.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Upgrade\Rector\Rector\String_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Scalar\String_;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Rename 'multicheckboxTitle' to 'multicheckboxLabel' in FormHelper templates
+ * for CakePHP 6.0
+ */
+final class RenameFormHelperTemplateKeyRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Rename \'multicheckboxTitle\' to \'multicheckboxLabel\' in FormHelper template configurations',
+            [
+                new CodeSample(
+                    <<<'CODE'
+$this->Form->setTemplates([
+    'multicheckboxTitle' => '<legend>{{text}}</legend>',
+]);
+CODE
+                    ,
+                    <<<'CODE'
+$this->Form->setTemplates([
+    'multicheckboxLabel' => '<legend>{{text}}</legend>',
+]);
+CODE,
+                ),
+            ],
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [ArrayItem::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if (!$node instanceof ArrayItem) {
+            return null;
+        }
+
+        // Only process items with a key
+        if ($node->key === null) {
+            return null;
+        }
+
+        // Check if the key is a string with value 'multicheckboxTitle'
+        if (!$node->key instanceof String_) {
+            return null;
+        }
+
+        if ($node->key->value !== 'multicheckboxTitle') {
+            return null;
+        }
+
+        // Replace the key
+        $node->key = new String_('multicheckboxLabel');
+
+        return $node;
+    }
+}

--- a/tests/TestCase/Rector/MethodCall/RequestQueryParamRector/Fixture/fixture.php.inc
+++ b/tests/TestCase/Rector/MethodCall/RequestQueryParamRector/Fixture/fixture.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Cake\Upgrade\Test\TestCase\Rector\MethodCall\RequestQueryParamRector\Fixture;
+
+use Cake\Http\ServerRequest;
+
+function requestQueryParam()
+{
+    $request = new ServerRequest();
+    $queryParams = $request->getParam('?');
+
+    // Should not change - different parameter
+    $otherParam = $request->getParam('foo');
+}
+
+?>
+-----
+<?php
+
+namespace Cake\Upgrade\Test\TestCase\Rector\MethodCall\RequestQueryParamRector\Fixture;
+
+use Cake\Http\ServerRequest;
+
+function requestQueryParam()
+{
+    $request = new ServerRequest();
+    $queryParams = $request->getQueryParams();
+
+    // Should not change - different parameter
+    $otherParam = $request->getParam('foo');
+}
+
+?>

--- a/tests/TestCase/Rector/MethodCall/RequestQueryParamRector/RequestQueryParamRectorTest.php
+++ b/tests/TestCase/Rector/MethodCall/RequestQueryParamRector/RequestQueryParamRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Upgrade\Test\TestCase\Rector\MethodCall\RequestQueryParamRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RequestQueryParamRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/TestCase/Rector/MethodCall/RequestQueryParamRector/config/configured_rule.php
+++ b/tests/TestCase/Rector/MethodCall/RequestQueryParamRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+use Cake\Upgrade\Rector\Rector\MethodCall\RequestQueryParamRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(RequestQueryParamRector::class);
+};

--- a/tests/TestCase/Rector/MethodCall/TextInsertPlaceholderRector/Fixture/fixture.php.inc
+++ b/tests/TestCase/Rector/MethodCall/TextInsertPlaceholderRector/Fixture/fixture.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Cake\Upgrade\Test\TestCase\Rector\MethodCall\TextInsertPlaceholderRector\Fixture;
+
+use Cake\Utility\Text;
+
+function textInsertPlaceholder()
+{
+    // Basic transformation
+    $result1 = Text::insert('Hello :name', ['name' => 'World']);
+
+    // Multiple placeholders
+    $result2 = Text::insert('Hello :first :last', ['first' => 'John', 'last' => 'Doe']);
+
+    // With underscore
+    $result3 = Text::insert('User: :user_name', ['user_name' => 'admin']);
+
+    // Should not change - custom before/after options
+    $result4 = Text::insert('Hello :name', ['name' => 'World'], ['before' => ':', 'after' => '']);
+}
+
+?>
+-----
+<?php
+
+namespace Cake\Upgrade\Test\TestCase\Rector\MethodCall\TextInsertPlaceholderRector\Fixture;
+
+use Cake\Utility\Text;
+
+function textInsertPlaceholder()
+{
+    // Basic transformation
+    $result1 = Text::insert('Hello {name}', ['name' => 'World']);
+
+    // Multiple placeholders
+    $result2 = Text::insert('Hello {first} {last}', ['first' => 'John', 'last' => 'Doe']);
+
+    // With underscore
+    $result3 = Text::insert('User: {user_name}', ['user_name' => 'admin']);
+
+    // Should not change - custom before/after options
+    $result4 = Text::insert('Hello :name', ['name' => 'World'], ['before' => ':', 'after' => '']);
+}
+
+?>

--- a/tests/TestCase/Rector/MethodCall/TextInsertPlaceholderRector/TextInsertPlaceholderRectorTest.php
+++ b/tests/TestCase/Rector/MethodCall/TextInsertPlaceholderRector/TextInsertPlaceholderRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Upgrade\Test\TestCase\Rector\MethodCall\TextInsertPlaceholderRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class TextInsertPlaceholderRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/TestCase/Rector/MethodCall/TextInsertPlaceholderRector/config/configured_rule.php
+++ b/tests/TestCase/Rector/MethodCall/TextInsertPlaceholderRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+use Cake\Upgrade\Rector\Rector\MethodCall\TextInsertPlaceholderRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(TextInsertPlaceholderRector::class);
+};

--- a/tests/TestCase/Rector/String_/RenameFormHelperTemplateKeyRector/Fixture/fixture.php.inc
+++ b/tests/TestCase/Rector/String_/RenameFormHelperTemplateKeyRector/Fixture/fixture.php.inc
@@ -1,0 +1,55 @@
+<?php
+
+namespace Cake\Upgrade\Test\TestCase\Rector\String_\RenameFormHelperTemplateKeyRector\Fixture;
+
+class SomeController
+{
+    public function index()
+    {
+        // In FormHelper setTemplates
+        $this->Form->setTemplates([
+            'multicheckboxTitle' => '<legend>{{text}}</legend>',
+            'inputContainer' => '<div class="input">{{content}}</div>',
+        ]);
+
+        // In config array
+        $config = [
+            'templates' => [
+                'multicheckboxTitle' => '<div>{{text}}</div>',
+            ],
+        ];
+
+        // Should not change - as a value, not a key
+        $someVar = 'multicheckboxTitle';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Cake\Upgrade\Test\TestCase\Rector\String_\RenameFormHelperTemplateKeyRector\Fixture;
+
+class SomeController
+{
+    public function index()
+    {
+        // In FormHelper setTemplates
+        $this->Form->setTemplates([
+            'multicheckboxLabel' => '<legend>{{text}}</legend>',
+            'inputContainer' => '<div class="input">{{content}}</div>',
+        ]);
+
+        // In config array
+        $config = [
+            'templates' => [
+                'multicheckboxLabel' => '<div>{{text}}</div>',
+            ],
+        ];
+
+        // Should not change - as a value, not a key
+        $someVar = 'multicheckboxTitle';
+    }
+}
+
+?>

--- a/tests/TestCase/Rector/String_/RenameFormHelperTemplateKeyRector/RenameFormHelperTemplateKeyRectorTest.php
+++ b/tests/TestCase/Rector/String_/RenameFormHelperTemplateKeyRector/RenameFormHelperTemplateKeyRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Upgrade\Test\TestCase\Rector\String_\RenameFormHelperTemplateKeyRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RenameFormHelperTemplateKeyRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/TestCase/Rector/String_/RenameFormHelperTemplateKeyRector/config/configured_rule.php
+++ b/tests/TestCase/Rector/String_/RenameFormHelperTemplateKeyRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+use Cake\Upgrade\Rector\Rector\String_\RenameFormHelperTemplateKeyRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(RenameFormHelperTemplateKeyRector::class);
+};


### PR DESCRIPTION
Implement some more of https://github.com/cakephp/docs/blob/6.x/en/appendices/6-0-migration-guide.rst

## Overview

Three new Rector rules have been implemented to automate CakePHP 6.0 migration changes that were previously not covered.

---

## 1. RequestQueryParamRector

**File**: `src/Rector/Rector/MethodCall/RequestQueryParamRector.php`

**Purpose**: Replace `$request->getParam('?')` with `$request->getQueryParams()`

**Migration Guide Reference**: Section 2.3 - Query Parameter Access Change

### What it does:
- Detects `$request->getParam('?')` calls on `Cake\Http\ServerRequest` instances
- Replaces them with `$request->getQueryParams()` (no arguments)
- Only transforms when the argument is exactly the string `'?'`

### Example:
```php
// Before
$queryParams = $request->getParam('?');

// After
$queryParams = $request->getQueryParams();
```

---

## 2. TextInsertPlaceholderRector

**File**: `src/Rector/Rector/MethodCall/TextInsertPlaceholderRector.php`

**Purpose**: Replace `:placeholder` with `{placeholder}` in `Text::insert()` calls

**Migration Guide Reference**: Section 2.4 - Text::insert() Placeholder Format Change

### What it does:
- Detects `Text::insert()` static calls
- Transforms placeholder format from `:name` to `{name}` in template strings
- **Respects backward compatibility**: Skips transformation if `'before'` or `'after'` options are explicitly set
- Uses regex pattern `/:(\w+)/` to match placeholders (word characters only)

### Example:
```php
// Before
Text::insert('Hello :name', ['name' => 'World']);
Text::insert('Hello :first :last', ['first' => 'John', 'last' => 'Doe']);

// After
Text::insert('Hello {name}', ['name' => 'World']);
Text::insert('Hello {first} {last}', ['first' => 'John', 'last' => 'Doe']);

// Not transformed (custom options)
Text::insert('Hello :name', ['name' => 'World'], ['before' => ':', 'after' => '']);
```

---

## 3. RenameFormHelperTemplateKeyRector

**File**: `src/Rector/Rector/String_/RenameFormHelperTemplateKeyRector.php`

**Purpose**: Rename `'multicheckboxTitle'` to `'multicheckboxLabel'` in FormHelper template configurations

**Migration Guide Reference**: Section 2.6 - FormHelper Template Key Rename

### What it does:
- Detects array items with string key `'multicheckboxTitle'`
- Renames the key to `'multicheckboxLabel'`
- **Context-aware**: Only transforms when used as an array key (not as a value)

### Example:
```php
// Before
$this->Form->setTemplates([
    'multicheckboxTitle' => '<legend>{{text}}</legend>',
    'inputContainer' => '<div class="input">{{content}}</div>',
]);

// After
$this->Form->setTemplates([
    'multicheckboxLabel' => '<legend>{{text}}</legend>',
    'inputContainer' => '<div class="input">{{content}}</div>',
]);

// Not transformed (used as value, not key)
$someVar = 'multicheckboxTitle';
```