### PR TITLE
Add rector rule to rename Form::_execute() to process()

### DIFF
--- a/config/rector/sets/cakephp53.php
+++ b/config/rector/sets/cakephp53.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use Cake\Upgrade\Rector\Rector\ClassMethod\FormExecuteToProcessRector;
 use Cake\Upgrade\Rector\Rector\MethodCall\EntityIsEmptyRector;
 use Cake\Upgrade\Rector\Rector\MethodCall\EntityPatchRector;
 use Cake\Upgrade\Rector\Rector\MethodCall\NewExprToFuncRector;
@@ -24,4 +25,5 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
     $rectorConfig->rule(EntityIsEmptyRector::class);
     $rectorConfig->rule(EntityPatchRector::class);
+    $rectorConfig->rule(FormExecuteToProcessRector::class);
 };

--- a/src/Rector/Rector/ClassMethod/FormExecuteToProcessRector.php
+++ b/src/Rector/Rector/ClassMethod/FormExecuteToProcessRector.php
@@ -1,0 +1,110 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Upgrade\Rector\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Type\ObjectType;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Renames Form _execute() to process() if process() doesn't exist.
+ *
+ * Form::_execute() is deprecated in CakePHP 5.x. The method should be renamed to process()
+ * which accepts the same parameters and has the same return type.
+ */
+final class FormExecuteToProcessRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Rename Form _execute() to process() if process() doesn\'t exist',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use Cake\Form\Form;
+
+class ContactForm extends Form
+{
+    protected function _execute(array $data, $form): bool
+    {
+        // Send email or save data
+        return true;
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+use Cake\Form\Form;
+
+class ContactForm extends Form
+{
+    protected function process(array $data, $form): bool
+    {
+        // Send email or save data
+        return true;
+    }
+}
+CODE_SAMPLE,
+                ),
+            ],
+        );
+    }
+
+    /**
+     * @return array<class-string<\PhpParser\Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param \PhpParser\Node\Stmt\Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (!$this->isObjectType($node, new ObjectType('Cake\Form\Form'))) {
+            return null;
+        }
+
+        // Check if process() already exists
+        $hasProcess = false;
+        foreach ($node->stmts as $stmt) {
+            if ($stmt instanceof ClassMethod && $this->isName($stmt->name, 'process')) {
+                $hasProcess = true;
+                break;
+            }
+        }
+
+        // If process() exists, don't rename _execute()
+        if ($hasProcess) {
+            return null;
+        }
+
+        // Find and rename _execute() method
+        $hasChanges = false;
+        foreach ($node->stmts as $stmt) {
+            if (!$stmt instanceof ClassMethod) {
+                continue;
+            }
+
+            if (!$this->isName($stmt->name, '_execute')) {
+                continue;
+            }
+
+            // Rename the method to process()
+            $stmt->name = new Identifier('process');
+
+            $hasChanges = true;
+            break;
+        }
+
+        return $hasChanges ? $node : null;
+    }
+}

--- a/tests/TestCase/Rector/ClassMethod/FormExecuteToProcessRector/Fixture/fixture.php.inc
+++ b/tests/TestCase/Rector/ClassMethod/FormExecuteToProcessRector/Fixture/fixture.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Cake\Upgrade\Test\TestCase\Rector\ClassMethod\FormExecuteToProcessRector\Fixture;
+
+use Cake\Form\Form;
+
+class ContactForm extends Form
+{
+    protected function _execute(array $data, $form): bool
+    {
+        // Send email or save data
+        return true;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Cake\Upgrade\Test\TestCase\Rector\ClassMethod\FormExecuteToProcessRector\Fixture;
+
+use Cake\Form\Form;
+
+class ContactForm extends Form
+{
+    protected function process(array $data, $form): bool
+    {
+        // Send email or save data
+        return true;
+    }
+}
+
+?>

--- a/tests/TestCase/Rector/ClassMethod/FormExecuteToProcessRector/Fixture/skip_when_process_exists.php.inc
+++ b/tests/TestCase/Rector/ClassMethod/FormExecuteToProcessRector/Fixture/skip_when_process_exists.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Cake\Upgrade\Test\TestCase\Rector\ClassMethod\FormExecuteToProcessRector\Fixture;
+
+use Cake\Form\Form;
+
+class ContactForm extends Form
+{
+    protected function _execute(array $data, $form): bool
+    {
+        // Old method
+        return true;
+    }
+
+    protected function process(array $data, $form): bool
+    {
+        // New method already exists
+        return true;
+    }
+}

--- a/tests/TestCase/Rector/ClassMethod/FormExecuteToProcessRector/FormExecuteToProcessRectorTest.php
+++ b/tests/TestCase/Rector/ClassMethod/FormExecuteToProcessRector/FormExecuteToProcessRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Upgrade\Test\TestCase\Rector\ClassMethod\FormExecuteToProcessRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class FormExecuteToProcessRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/TestCase/Rector/ClassMethod/FormExecuteToProcessRector/config/configured_rule.php
+++ b/tests/TestCase/Rector/ClassMethod/FormExecuteToProcessRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+use Cake\Upgrade\Rector\Rector\ClassMethod\FormExecuteToProcessRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(FormExecuteToProcessRector::class);
+};


### PR DESCRIPTION
## Summary

Adds a new rector rule `FormExecuteToProcessRector` that automatically renames deprecated `Form::_execute()` methods to `process()` for CakePHP 5.3+.

- Form::_execute() is deprecated in CakePHP 5.x
- The new `process()` method accepts the same parameters and has the same return type
- The rule includes a safety check to skip renaming if `process()` already exists to avoid conflicts

## Changes

- **New Rector Rule**: `src/Rector/Rector/ClassMethod/FormExecuteToProcessRector.php`
  - Handles renaming `_execute()` to `process()` in Form classes
  - Preserves method signature (parameters and return type)
  - Skips transformation if `process()` already exists

- **Tests**: Complete test coverage with:
  - Basic transformation test
  - Skip logic test (when process() already exists)
  - All tests passing ✓

- **Configuration**: Added to `config/rector/sets/cakephp53.php` for CakePHP 5.3 migration

## Test plan

- [x] Unit tests pass (2 tests, 3 assertions)
- [x] Code style check (phpcs) passes
- [x] PHPStan analysis passes
- [x] Integration test verified with sample Form class
- [x] Skip logic verified when process() method exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)