### PR TITLE
Add no-diff option

### DIFF
--- a/src/Command/RectorCommand.php
+++ b/src/Command/RectorCommand.php
@@ -83,10 +83,11 @@ class RectorCommand extends BaseCommand
 
         $cmdPath = ROOT . '/vendor/bin/rector process';
         $command = sprintf(
-            '%s %s %s --autoload-file=%s --config=%s %s --clear-cache',
+            '%s %s %s %s --autoload-file=%s --config=%s %s --clear-cache',
             $cmdPath,
             $args->getOption('dry-run') ? '--dry-run' : '',
             $args->getOption('verbose') ? '--debug' : '',
+            $args->getOption('no-diff') ? '--no-diff' : '',
             escapeshellarg($autoload),
             escapeshellarg($config),
             escapeshellarg($path),
@@ -198,6 +199,10 @@ class RectorCommand extends BaseCommand
             ])
             ->addOption('dry-run', [
                 'help' => 'Enable to get a preview of what modifications will be applied.',
+                'boolean' => true,
+            ])
+            ->addOption('no-diff', [
+                'help' => 'Disable rector diff output which can cause issues with large files.',
                 'boolean' => true,
             ]);
 

--- a/tests/TestCase/Command/RectorCommandTest.php
+++ b/tests/TestCase/Command/RectorCommandTest.php
@@ -68,6 +68,16 @@ class RectorCommandTest extends TestCase
         $this->assertOutputContains('Rector applied successfully');
     }
 
+    public function testApplyNoDiff()
+    {
+        $this->setupTestApp(__FUNCTION__);
+        $this->exec('upgrade rector --rules cakephp40 --dry-run --no-diff ' . TEST_APP);
+
+        $this->assertExitSuccess();
+        $this->assertOutputNotContains('begin diff');
+        $this->assertOutputContains('Rector applied successfully');
+    }
+
     /**
      * @return void
      */


### PR DESCRIPTION
Rector soft-locks when generating the diff on large files.