### PR TITLE
Add Migrations 5.0 rector rules for PHINX_TYPE_* constant renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The upgrade tool also includes rulesets for related tools and libraries:
 
 - **chronos3** - Upgrade to Chronos 3.x
 - **migrations45** - Upgrade to Migrations 4.5
+- **migrations50** - Upgrade to Migrations 5.0
 - **phpunit80** - Upgrade to PHPUnit 8.0
 
 ```bash
@@ -113,6 +114,9 @@ bin/cake upgrade rector --rules chronos3 /path/to/your/app/src
 
 # Apply Migrations 4.5 upgrade rules
 bin/cake upgrade rector --rules migrations45 /path/to/your/app/config
+
+# Apply Migrations 5.0 upgrade rules
+bin/cake upgrade rector --rules migrations50 /path/to/your/app/config
 
 # Apply PHPUnit 8.0 upgrade rules
 bin/cake upgrade rector --rules phpunit80 /path/to/your/app/tests

--- a/config/rector/migrations50.php
+++ b/config/rector/migrations50.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+use Cake\Upgrade\Rector\Set\CakePHPSetList;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([CakePHPSetList::MIGRATIONS_50]);
+};

--- a/config/rector/sets/migrations50.php
+++ b/config/rector/sets/migrations50.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\ClassConstFetch\RenameClassConstFetchRector;
+use Rector\Renaming\ValueObject\RenameClassConstFetch;
+
+/**
+ * @see https://github.com/cakephp/migrations/releases/5.0.0/
+ */
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(RenameClassConstFetchRector::class, [
+        // Standard types
+        new RenameClassConstFetch('Migrations\Db\Adapter\AdapterInterface', 'PHINX_TYPE_STRING', 'TYPE_STRING'),
+        new RenameClassConstFetch('Migrations\Db\Adapter\AdapterInterface', 'PHINX_TYPE_CHAR', 'TYPE_CHAR'),
+        new RenameClassConstFetch('Migrations\Db\Adapter\AdapterInterface', 'PHINX_TYPE_TEXT', 'TYPE_TEXT'),
+        new RenameClassConstFetch('Migrations\Db\Adapter\AdapterInterface', 'PHINX_TYPE_INTEGER', 'TYPE_INTEGER'),
+        new RenameClassConstFetch('Migrations\Db\Adapter\AdapterInterface', 'PHINX_TYPE_TINY_INTEGER', 'TYPE_TINYINTEGER'),
+        new RenameClassConstFetch('Migrations\Db\Adapter\AdapterInterface', 'PHINX_TYPE_SMALL_INTEGER', 'TYPE_SMALLINTEGER'),
+        new RenameClassConstFetch('Migrations\Db\Adapter\AdapterInterface', 'PHINX_TYPE_BIG_INTEGER', 'TYPE_BIGINTEGER'),
+        new RenameClassConstFetch('Migrations\Db\Adapter\AdapterInterface', 'PHINX_TYPE_FLOAT', 'TYPE_FLOAT'),
+        new RenameClassConstFetch('Migrations\Db\Adapter\AdapterInterface', 'PHINX_TYPE_DECIMAL', 'TYPE_DECIMAL'),
+        new RenameClassConstFetch('Migrations\Db\Adapter\AdapterInterface', 'PHINX_TYPE_DATETIME', 'TYPE_DATETIME'),
+        new RenameClassConstFetch('Migrations\Db\Adapter\AdapterInterface', 'PHINX_TYPE_TIMESTAMP', 'TYPE_TIMESTAMP'),
+        new RenameClassConstFetch('Migrations\Db\Adapter\AdapterInterface', 'PHINX_TYPE_TIME', 'TYPE_TIME'),
+        new RenameClassConstFetch('Migrations\Db\Adapter\AdapterInterface', 'PHINX_TYPE_DATE', 'TYPE_DATE'),
+        new RenameClassConstFetch('Migrations\Db\Adapter\AdapterInterface', 'PHINX_TYPE_BINARY', 'TYPE_BINARY'),
+        new RenameClassConstFetch('Migrations\Db\Adapter\AdapterInterface', 'PHINX_TYPE_BINARYUUID', 'TYPE_BINARY_UUID'),
+        new RenameClassConstFetch('Migrations\Db\Adapter\AdapterInterface', 'PHINX_TYPE_BOOLEAN', 'TYPE_BOOLEAN'),
+        new RenameClassConstFetch('Migrations\Db\Adapter\AdapterInterface', 'PHINX_TYPE_JSON', 'TYPE_JSON'),
+        new RenameClassConstFetch('Migrations\Db\Adapter\AdapterInterface', 'PHINX_TYPE_UUID', 'TYPE_UUID'),
+        new RenameClassConstFetch('Migrations\Db\Adapter\AdapterInterface', 'PHINX_TYPE_NATIVEUUID', 'TYPE_NATIVE_UUID'),
+
+        // Geospatial types
+        new RenameClassConstFetch('Migrations\Db\Adapter\AdapterInterface', 'PHINX_TYPE_GEOMETRY', 'TYPE_GEOMETRY'),
+        new RenameClassConstFetch('Migrations\Db\Adapter\AdapterInterface', 'PHINX_TYPE_POINT', 'TYPE_POINT'),
+        new RenameClassConstFetch('Migrations\Db\Adapter\AdapterInterface', 'PHINX_TYPE_LINESTRING', 'TYPE_LINESTRING'),
+        new RenameClassConstFetch('Migrations\Db\Adapter\AdapterInterface', 'PHINX_TYPE_POLYGON', 'TYPE_POLYGON'),
+
+        // Geospatial array constant
+        new RenameClassConstFetch('Migrations\Db\Adapter\AdapterInterface', 'PHINX_TYPES_GEOSPATIAL', 'TYPES_GEOSPATIAL'),
+
+        // Database-specific types
+        new RenameClassConstFetch('Migrations\Db\Adapter\AdapterInterface', 'PHINX_TYPE_YEAR', 'TYPE_YEAR'),
+        new RenameClassConstFetch('Migrations\Db\Adapter\AdapterInterface', 'PHINX_TYPE_CIDR', 'TYPE_CIDR'),
+        new RenameClassConstFetch('Migrations\Db\Adapter\AdapterInterface', 'PHINX_TYPE_INET', 'TYPE_INET'),
+        new RenameClassConstFetch('Migrations\Db\Adapter\AdapterInterface', 'PHINX_TYPE_MACADDR', 'TYPE_MACADDR'),
+        new RenameClassConstFetch('Migrations\Db\Adapter\AdapterInterface', 'PHINX_TYPE_INTERVAL', 'TYPE_INTERVAL'),
+    ]);
+};

--- a/src/Rector/Set/CakePHPSetList.php
+++ b/src/Rector/Set/CakePHPSetList.php
@@ -98,5 +98,10 @@ final class CakePHPSetList
     /**
      * @var string
      */
+    public const MIGRATIONS_50 = __DIR__ . '/../../../config/rector/sets/migrations50.php';
+
+    /**
+     * @var string
+     */
     public const CAKEPHP_FLUENT_OPTIONS = __DIR__ . '/../../../config/rector/sets/cakephp-fluent-options.php';
 }


### PR DESCRIPTION
# Add Migrations 5.0 rector rules for PHINX_TYPE_* constant renaming

## Summary

This PR adds rector rules to automatically upgrade migrations from the deprecated `PHINX_TYPE_*` constants to the new `TYPE_*` constants introduced in Migrations 5.0.

## Changes

- ✅ Add `config/rector/migrations50.php` entry point
- ✅ Add `config/rector/sets/migrations50.php` with constant rename rules
- ✅ Update `CakePHPSetList` with `MIGRATIONS_50` constant
- ✅ Update `README.md` with migrations50 documentation

## Usage

Users can now upgrade their migrations using:

```bash
cd /path/to/upgrade
bin/cake upgrade rector --rules migrations50 /path/to/your/app/config
```

## Details

The rules rename all deprecated `PHINX_TYPE_*` constants to their new `TYPE_*` equivalents, matching the naming conventions of `Cake\Database\Schema\TableSchemaInterface`:

### Standard Types
- `PHINX_TYPE_STRING` → `TYPE_STRING`
- `PHINX_TYPE_INTEGER` → `TYPE_INTEGER`
- `PHINX_TYPE_BOOLEAN` → `TYPE_BOOLEAN`
- etc.

### Multi-word Types (no underscores)
- `PHINX_TYPE_TINY_INTEGER` → `TYPE_TINYINTEGER`
- `PHINX_TYPE_SMALL_INTEGER` → `TYPE_SMALLINTEGER`
- `PHINX_TYPE_BIG_INTEGER` → `TYPE_BIGINTEGER`

### UUID Types (with underscores)
- `PHINX_TYPE_BINARYUUID` → `TYPE_BINARY_UUID`
- `PHINX_TYPE_NATIVEUUID` → `TYPE_NATIVE_UUID`

### Geospatial Types
- `PHINX_TYPE_GEOMETRY` → `TYPE_GEOMETRY`
- `PHINX_TYPE_POINT` → `TYPE_POINT`
- `PHINX_TYPE_LINESTRING` → `TYPE_LINESTRING`
- `PHINX_TYPE_POLYGON` → `TYPE_POLYGON`
- `PHINX_TYPES_GEOSPATIAL` → `TYPES_GEOSPATIAL`

### Database-specific Types
- `PHINX_TYPE_YEAR` → `TYPE_YEAR` (MySQL)
- `PHINX_TYPE_CIDR` → `TYPE_CIDR` (PostgreSQL)
- `PHINX_TYPE_INET` → `TYPE_INET` (PostgreSQL)
- `PHINX_TYPE_MACADDR` → `TYPE_MACADDR` (PostgreSQL)
- `PHINX_TYPE_INTERVAL` → `TYPE_INTERVAL` (PostgreSQL)

## Related Issue

https://github.com/cakephp/migrations/issues/948

## Testing

The rector rules can be tested by running them against migration files that use the old constants. Example:

**Before:**
```php
$table->addColumn('name', AdapterInterface::PHINX_TYPE_STRING)
    ->addColumn('count', AdapterInterface::PHINX_TYPE_INTEGER)
    ->save();
```

**After:**
```php
$table->addColumn('name', AdapterInterface::TYPE_STRING)
    ->addColumn('count', AdapterInterface::TYPE_INTEGER)
    ->save();
```