### PR TITLE
Fix failing CI due to conflict with nikic/php-parser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         php-version: ${{ matrix.php-version }}
         extensions: mbstring, intl
-        coverage: pcov
+        coverage: none
 
     - name: Get composer cache directory
       id: composer-cache
@@ -62,16 +62,7 @@ jobs:
       run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
     - name: Run PHPUnit
-      run: |
-        if [[ ${{ matrix.php-version }} == '8.1' ]]; then
-          export CODECOVERAGE=1 && vendor/bin/phpunit --display-incomplete --display-skipped --coverage-clover=coverage.xml
-        else
-          vendor/bin/phpunit
-        fi
-
-    - name: Submit code coverage
-      if: matrix.php-version == '8.1'
-      uses: codecov/codecov-action@v5
+      run: vendor/bin/phpunit --display-incomplete --display-skipped
 
   cs-stan:
     name: Coding Standard & Static Analysis


### PR DESCRIPTION
## Summary

- Adds `nikic/php-parser` to the conflict section in composer.json

This fixes the CI failure where `phpunit/php-code-coverage` (a transitive dev dependency) pulls in `nikic/php-parser ^5.6.1`, which conflicts with rector's bundled/scoped version causing:

```
PHP Fatal error: Cannot declare class PhpParser\Node\Scalar\InterpolatedString,
because the name is already in use
```

The `prefer-lowest` job passes because it gets older versions of php-code-coverage that don't require php-parser directly.

Related: https://github.com/rectorphp/rector/discussions/6958


//EDIT:
 Updated the PR to disable code coverage in CI instead - that's the actual fix since the conflict happens when php-code-coverage loads php-parser.