### PR TITLE
Add rector rules for cakephp/authentication 4.x upgrade

### DIFF
--- a/config/rector/authentication40.php
+++ b/config/rector/authentication40.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+use Cake\Upgrade\Rector\Set\CakePHPSetList;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([CakePHPSetList::AUTHENTICATION_40]);
+};

--- a/config/rector/sets/authentication40.php
+++ b/config/rector/sets/authentication40.php
@@ -11,11 +11,11 @@ use Rector\Renaming\Rector\Name\RenameClassRector;
  */
 return static function (RectorConfig $rectorConfig): void {
     // URL checker class renames
-    // Note: Order matters - GenericUrlChecker rename must come first to avoid
-    // CakeRouterUrlChecker -> DefaultUrlChecker -> GenericUrlChecker chain
+    // Note: Order matters - StringUrlChecker rename must come first to avoid
+    // CakeRouterUrlChecker -> DefaultUrlChecker -> StringUrlChecker chain
     $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
-        // Old framework-agnostic DefaultUrlChecker renamed to GenericUrlChecker
-        'Authentication\UrlChecker\DefaultUrlChecker' => 'Authentication\UrlChecker\GenericUrlChecker',
+        // Old DefaultUrlChecker renamed to StringUrlChecker
+        'Authentication\UrlChecker\DefaultUrlChecker' => 'Authentication\UrlChecker\StringUrlChecker',
         // CakeRouterUrlChecker renamed to DefaultUrlChecker
         'Authentication\UrlChecker\CakeRouterUrlChecker' => 'Authentication\UrlChecker\DefaultUrlChecker',
         // Plugin class renamed

--- a/config/rector/sets/authentication40.php
+++ b/config/rector/sets/authentication40.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+use Cake\Upgrade\Rector\Rector\MethodCall\RemoveMethodCallRector;
+use Cake\Upgrade\Rector\ValueObject\RemoveMethodCall;
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+
+/**
+ * @see https://github.com/cakephp/authentication/blob/4.x/docs/en/upgrade-3-to-4.rst
+ */
+return static function (RectorConfig $rectorConfig): void {
+    // URL checker class renames
+    // Note: Order matters - GenericUrlChecker rename must come first to avoid
+    // CakeRouterUrlChecker -> DefaultUrlChecker -> GenericUrlChecker chain
+    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
+        // Old framework-agnostic DefaultUrlChecker renamed to GenericUrlChecker
+        'Authentication\UrlChecker\DefaultUrlChecker' => 'Authentication\UrlChecker\GenericUrlChecker',
+        // CakeRouterUrlChecker renamed to DefaultUrlChecker
+        'Authentication\UrlChecker\CakeRouterUrlChecker' => 'Authentication\UrlChecker\DefaultUrlChecker',
+        // Plugin class renamed
+        'Authentication\Plugin' => 'Authentication\AuthenticationPlugin',
+    ]);
+
+    // Remove loadIdentifier() method calls from AuthenticationService
+    $rectorConfig->ruleWithConfiguration(RemoveMethodCallRector::class, [
+        new RemoveMethodCall('Authentication\AuthenticationService', 'loadIdentifier'),
+        new RemoveMethodCall('Authentication\AuthenticationServiceInterface', 'loadIdentifier'),
+    ]);
+};

--- a/src/Rector/Set/CakePHPSetList.php
+++ b/src/Rector/Set/CakePHPSetList.php
@@ -104,4 +104,9 @@ final class CakePHPSetList
      * @var string
      */
     public const CAKEPHP_FLUENT_OPTIONS = __DIR__ . '/../../../config/rector/sets/cakephp-fluent-options.php';
+
+    /**
+     * @var string
+     */
+    public const AUTHENTICATION_40 = __DIR__ . '/../../../config/rector/sets/authentication40.php';
 }


### PR DESCRIPTION
## Summary

Adds rector rules to automate the Authentication plugin 3.x to 4.x migration:

- **Class renames:**
  - `Authentication\UrlChecker\CakeRouterUrlChecker` → `Authentication\UrlChecker\DefaultUrlChecker`
  - `Authentication\UrlChecker\DefaultUrlChecker` (framework-agnostic) → `Authentication\UrlChecker\GenericUrlChecker`
  - `Authentication\Plugin` → `Authentication\AuthenticationPlugin`

- **Method removal:**
  - `AuthenticationService::loadIdentifier()` - removed in 4.x

## Usage

```bash
bin/cake upgrade rector --rules authentication40
```

Or in custom rector config:

```php
use Cake\Upgrade\Rector\Set\CakePHPSetList;

return static function (RectorConfig $rectorConfig): void {
    $rectorConfig->sets([CakePHPSetList::AUTHENTICATION_40]);
};
```

## Not automated

Some changes require manual intervention and are documented in the upgrade guide:

1. **Constant relocations** - `CREDENTIAL_USERNAME`/`CREDENTIAL_PASSWORD` moved from `AbstractIdentifier` to `PasswordIdentifier`/`LdapIdentifier`
2. **IdentifierCollection removal** - Identifiers are now configured per-authenticator
3. **MultiUrlChecker** - Auto-detection removed, requires explicit configuration

## Related

- Authentication 4.x PR: https://github.com/cakephp/authentication/pull/748
- Upgrade guide: https://github.com/cakephp/authentication/blob/4.x/docs/en/upgrade-3-to-4.rst