### PR TITLE
Fix use of removed parent attribute on StaticConnectionHelperRector

### DIFF
--- a/src/Rector/Rector/MethodCall/StaticConnectionHelperRector.php
+++ b/src/Rector/Rector/MethodCall/StaticConnectionHelperRector.php
@@ -43,9 +43,6 @@ CODE_SAMPLE,
         return [Expression::class, MethodCall::class];
     }
 
-    /**
-     * @return null|NodeVisitor::REMOVE_NODE|Node
-     */
     public function refactor(Node $node): null|int|Node
     {
         if ($node instanceof Expression) {

--- a/src/Rector/Rector/MethodCall/StaticConnectionHelperRector.php
+++ b/src/Rector/Rector/MethodCall/StaticConnectionHelperRector.php
@@ -10,8 +10,8 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Stmt\Expression;
+use PhpParser\NodeVisitor;
 use PHPStan\Type\ObjectType;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -40,25 +40,24 @@ CODE_SAMPLE,
 
     public function getNodeTypes(): array
     {
-        return [MethodCall::class, Assign::class];
+        return [Expression::class, MethodCall::class];
     }
 
-    public function refactor(Node $node): ?Node
+    /**
+     * @return null|NodeVisitor::REMOVE_NODE|Node
+     */
+    public function refactor(Node $node): null|int|Node
     {
-        if ($node instanceof Assign) {
-            if ($node->expr instanceof New_ && $this->isName($node->expr->class, 'ConnectionHelper')) {
-                // Remove the instantiation statement
-                $parent = $node->getAttribute(AttributeKey::PARENT_NODE);
-                if ($parent instanceof Expression) {
-                    $this->removeNode($parent);
-                }
+        if ($node instanceof Expression) {
+            if ($node->expr instanceof Assign && $node->expr->expr instanceof New_ && $this->isName($node->expr->expr->class, 'ConnectionHelper')) {
+                return NodeVisitor::REMOVE_NODE;
             }
 
             return null;
         }
 
         // Ensure the node is a method call on the ConnectionHelper instance
-        if (! $this->isObjectType($node->var, new ObjectType(ConnectionHelper::class))) {
+        if (! $this->isObjectType($node->var, new ObjectType('ConnectionHelper'))) {
             return null;
         }
 

--- a/src/Rector/Rector/MethodCall/StaticConnectionHelperRector.php
+++ b/src/Rector/Rector/MethodCall/StaticConnectionHelperRector.php
@@ -43,7 +43,7 @@ CODE_SAMPLE,
         return [Expression::class, MethodCall::class];
     }
 
-    public function refactor(Node $node): null|int|Node
+    public function refactor(Node $node): int|Node|null
     {
         if ($node instanceof Expression) {
             if ($node->expr instanceof Assign && $node->expr->expr instanceof New_ && $this->isName($node->expr->expr->class, 'ConnectionHelper')) {

--- a/src/Rector/Rector/MethodCall/StaticConnectionHelperRector.php
+++ b/src/Rector/Rector/MethodCall/StaticConnectionHelperRector.php
@@ -46,7 +46,11 @@ CODE_SAMPLE,
     public function refactor(Node $node): int|Node|null
     {
         if ($node instanceof Expression) {
-            if ($node->expr instanceof Assign && $node->expr->expr instanceof New_ && $this->isName($node->expr->expr->class, 'ConnectionHelper')) {
+            if (
+                $node->expr instanceof Assign &&
+                $node->expr->expr instanceof New_ &&
+                $this->isName($node->expr->expr->class, 'ConnectionHelper')
+            ) {
                 return NodeVisitor::REMOVE_NODE;
             }
 

--- a/src/Rector/Rector/MethodCall/StaticConnectionHelperRector.php
+++ b/src/Rector/Rector/MethodCall/StaticConnectionHelperRector.php
@@ -49,7 +49,7 @@ CODE_SAMPLE,
             if (
                 $node->expr instanceof Assign &&
                 $node->expr->expr instanceof New_ &&
-                $this->isName($node->expr->expr->class, 'ConnectionHelper')
+                $this->isName($node->expr->expr->class, ConnectionHelper::class)
             ) {
                 return NodeVisitor::REMOVE_NODE;
             }
@@ -58,7 +58,7 @@ CODE_SAMPLE,
         }
 
         // Ensure the node is a method call on the ConnectionHelper instance
-        if (! $this->isObjectType($node->var, new ObjectType('ConnectionHelper'))) {
+        if (! $this->isObjectType($node->var, new ObjectType(ConnectionHelper::class))) {
             return null;
         }
 

--- a/tests/TestCase/Rector/MethodCall/StaticConnectionHelperRector/Fixture/fixture.php.inc
+++ b/tests/TestCase/Rector/MethodCall/StaticConnectionHelperRector/Fixture/fixture.php.inc
@@ -6,7 +6,7 @@ class Fixture
 {
     public function run()
     {
-        $connectionHelper = new \ConnectionHelper();
+        $connectionHelper = new \Cake\TestSuite\ConnectionHelper();
         $connection = $connectionHelper->getConnection('default');
 
         return $connection;

--- a/tests/TestCase/Rector/MethodCall/StaticConnectionHelperRector/Fixture/fixture.php.inc
+++ b/tests/TestCase/Rector/MethodCall/StaticConnectionHelperRector/Fixture/fixture.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Cake\Upgrade\Test\TestCase\Rector\MethodCall\StaticConnectionHelperRector\Fixture;
+
+class Fixture
+{
+    public function run()
+    {
+        $connectionHelper = new \ConnectionHelper();
+        $connection = $connectionHelper->getConnection('default');
+
+        return $connection;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Cake\Upgrade\Test\TestCase\Rector\MethodCall\StaticConnectionHelperRector\Fixture;
+
+class Fixture
+{
+    public function run()
+    {
+        $connection = \Cake\TestSuite\ConnectionHelper::getConnection('default');
+
+        return $connection;
+    }
+}
+
+?>

--- a/tests/TestCase/Rector/MethodCall/StaticConnectionHelperRector/StaticConnectionHelperRectorTest.php
+++ b/tests/TestCase/Rector/MethodCall/StaticConnectionHelperRector/StaticConnectionHelperRectorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cake\Upgrade\Test\TestCase\Rector\MethodCall\StaticConnectionHelperRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class StaticConnectionHelperRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/TestCase/Rector/MethodCall/StaticConnectionHelperRector/config/configured_rule.php
+++ b/tests/TestCase/Rector/MethodCall/StaticConnectionHelperRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Cake\Upgrade\Rector\Rector\MethodCall\StaticConnectionHelperRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(StaticConnectionHelperRector::class);
+};

--- a/tests/test_apps/upgraded/RectorCommand-testApply51/src/SomeTest.php
+++ b/tests/test_apps/upgraded/RectorCommand-testApply51/src/SomeTest.php
@@ -27,7 +27,6 @@ class SomeTest extends TestCase
 
     public function testConnectionHelper()
     {
-        $connectionHelper = new ConnectionHelper();
         $connection = ConnectionManager::get('test');
         \Cake\TestSuite\ConnectionHelper::runWithoutConstraints($connection, function ($connection) {
             $connection->execute('SELECT * FROM table');


### PR DESCRIPTION
`AttributeKey::PARENT_NODE` no longer exists from rector 0.17 https://getrector.com/blog/rector-017-brings-more-robust-and-lighter-node-tree

seems this is left over on upgrade and was missing test.

This PR fix it. 