### PR TITLE
Add translation() => getOrCreateTranslation() rector rule for 6.x

### DIFF
--- a/config/rector/sets/cakephp60.php
+++ b/config/rector/sets/cakephp60.php
@@ -6,6 +6,7 @@ use Cake\Upgrade\Rector\Cake6\EventManagerOnRector;
 use Cake\Upgrade\Rector\Cake6\RemoveAssignmentFromVoidMethodRector;
 use Cake\Upgrade\Rector\Cake6\ReplaceCommandArgsIoWithPropertiesRector;
 use Cake\Upgrade\Rector\Cake6\RouteBuilderToCallbackFirstRector;
+use Cake\Upgrade\Rector\Cake6\TranslationToGetOrCreateTranslationRector;
 use Cake\Upgrade\Rector\Cake6\VoidMethod;
 use PHPStan\Type\ObjectType;
 use Rector\Config\RectorConfig;
@@ -29,6 +30,10 @@ return static function (RectorConfig $rectorConfig): void {
 
     // RouteBuilder argument reordering
     $rectorConfig->rule(RouteBuilderToCallbackFirstRector::class);
+
+    // TranslateTrait::translation() became a pure getter, use getOrCreateTranslation() for create-on-access
+    // @see https://github.com/cakephp/cakephp/pull/19251
+    $rectorConfig->rule(TranslationToGetOrCreateTranslationRector::class);
 
     // Changes related to the accessible => patchable rename
     $rectorConfig->ruleWithConfiguration(RenameMethodRector::class, [

--- a/src/Rector/Cake6/TranslationToGetOrCreateTranslationRector.php
+++ b/src/Rector/Cake6/TranslationToGetOrCreateTranslationRector.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Upgrade\Rector\Cake6;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Type\ObjectType;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Renames translation() to getOrCreateTranslation() for entities using TranslateTrait.
+ *
+ * In CakePHP 6.0, translation() became a pure getter that returns null if no translation exists.
+ * The old create-on-access behavior is now in getOrCreateTranslation().
+ *
+ * @see https://github.com/cakephp/cakephp/pull/19251
+ */
+final class TranslationToGetOrCreateTranslationRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Rename $entity->translation() to $entity->getOrCreateTranslation() to preserve create-on-access behavior',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+$article->translation('fra');
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+$article->getOrCreateTranslation('fra');
+CODE_SAMPLE,
+                ),
+            ],
+        );
+    }
+
+    /**
+     * @return array<class-string<\PhpParser\Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr\MethodCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (!$node->name instanceof Identifier) {
+            return null;
+        }
+
+        if ($node->name->toString() !== 'translation') {
+            return null;
+        }
+
+        if (!$this->isObjectType($node->var, new ObjectType('Cake\ORM\Entity'))) {
+            return null;
+        }
+
+        $node->name = new Identifier('getOrCreateTranslation');
+
+        return $node;
+    }
+}

--- a/tests/TestCase/Rector/MethodCall/TranslationToGetOrCreateTranslationRector/Fixture/fixture.php.inc
+++ b/tests/TestCase/Rector/MethodCall/TranslationToGetOrCreateTranslationRector/Fixture/fixture.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Cake\Upgrade\Test\TestCase\Rector\MethodCall\TranslationToGetOrCreateTranslationRector\Fixture;
+
+use Cake\ORM\Entity;
+
+class Article extends Entity
+{
+}
+
+class ArticlesController
+{
+    public function edit()
+    {
+        $article = new Article();
+
+        // Should transform: Entity->translation()
+        $translation = $article->translation('fra');
+
+        return $article;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Cake\Upgrade\Test\TestCase\Rector\MethodCall\TranslationToGetOrCreateTranslationRector\Fixture;
+
+use Cake\ORM\Entity;
+
+class Article extends Entity
+{
+}
+
+class ArticlesController
+{
+    public function edit()
+    {
+        $article = new Article();
+
+        // Should transform: Entity->translation()
+        $translation = $article->getOrCreateTranslation('fra');
+
+        return $article;
+    }
+}
+
+?>

--- a/tests/TestCase/Rector/MethodCall/TranslationToGetOrCreateTranslationRector/Fixture/skip_non_entity.php.inc
+++ b/tests/TestCase/Rector/MethodCall/TranslationToGetOrCreateTranslationRector/Fixture/skip_non_entity.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Cake\Upgrade\Test\TestCase\Rector\MethodCall\TranslationToGetOrCreateTranslationRector\Fixture;
+
+class SomeTranslationService
+{
+    public function translation(string $lang): ?string
+    {
+        return null;
+    }
+}
+
+class SomeController
+{
+    public function index()
+    {
+        $service = new SomeTranslationService();
+
+        // Should NOT transform: not an Entity subclass
+        $result = $service->translation('fra');
+
+        return $result;
+    }
+}
+
+?>

--- a/tests/TestCase/Rector/MethodCall/TranslationToGetOrCreateTranslationRector/TranslationToGetOrCreateTranslationRectorTest.php
+++ b/tests/TestCase/Rector/MethodCall/TranslationToGetOrCreateTranslationRector/TranslationToGetOrCreateTranslationRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Upgrade\Test\TestCase\Rector\MethodCall\TranslationToGetOrCreateTranslationRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class TranslationToGetOrCreateTranslationRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/TestCase/Rector/MethodCall/TranslationToGetOrCreateTranslationRector/config/configured_rule.php
+++ b/tests/TestCase/Rector/MethodCall/TranslationToGetOrCreateTranslationRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+use Cake\Upgrade\Rector\Cake6\TranslationToGetOrCreateTranslationRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(TranslationToGetOrCreateTranslationRector::class);
+};


### PR DESCRIPTION
## Summary

Adds a Rector rule for CakePHP 6.0 that transforms `$entity->translation('lang')` calls to `$entity->getOrCreateTranslation('lang')`.

In CakePHP 6.0, `TranslateTrait::translation()` becomes a pure getter that returns `null` if no translation exists. The old create-on-access behavior (creating an empty translation entity and marking it dirty) is now in `getOrCreateTranslation()`.

This rector rule preserves backward compatibility by renaming `translation()` calls to `getOrCreateTranslation()`, which maintains the same behavior as before the change.

**Before:**
```php
$article->translation('fra');  // Creates entity if missing, marks dirty
```

**After:**
```php
$article->getOrCreateTranslation('fra');  // Same behavior as old translation()
```

Refs: https://github.com/cakephp/cakephp/pull/19251