### PR TITLE
Add BinaryColumnToVarbinaryRector for TYPE_VARBINARY migration

### DIFF
--- a/config/rector/sets/cakephp60.php
+++ b/config/rector/sets/cakephp60.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use Cake\Upgrade\Rector\Cake6\BinaryColumnToVarbinaryRector;
 use Cake\Upgrade\Rector\Cake6\BreadcrumbsHelperTitleToContentRector;
 use Cake\Upgrade\Rector\Cake6\EventManagerOnRector;
 use Cake\Upgrade\Rector\Cake6\RemoveAssignmentFromVoidMethodRector;
@@ -1050,4 +1051,10 @@ return static function (RectorConfig $rectorConfig): void {
     // BreadcrumbsHelper 'title' key/parameter renamed to 'content'
     // @see https://github.com/cakephp/cakephp/pull/18334
     $rectorConfig->rule(BreadcrumbsHelperTitleToContentRector::class);
+
+    // Binary column type changes for TYPE_VARBINARY support
+    // 'binary' with 'fixed' => true becomes 'binary' (remove fixed)
+    // 'binary' without 'fixed' becomes 'varbinary'
+    // @see https://github.com/cakephp/cakephp/pull/19258
+    $rectorConfig->rule(BinaryColumnToVarbinaryRector::class);
 };

--- a/src/Rector/Cake6/BinaryColumnToVarbinaryRector.php
+++ b/src/Rector/Cake6/BinaryColumnToVarbinaryRector.php
@@ -1,0 +1,163 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Upgrade\Rector\Cake6;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\String_;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Transforms binary column definitions for CakePHP 6.0 TYPE_VARBINARY support.
+ *
+ * In CakePHP 6.0, a new TYPE_VARBINARY was added for variable-length binary columns.
+ * The 'fixed' attribute is no longer used - instead use 'binary' for fixed-length
+ * and 'varbinary' for variable-length binary columns.
+ *
+ * @see https://github.com/cakephp/cakephp/pull/19258
+ */
+final class BinaryColumnToVarbinaryRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Change binary column with fixed attribute to use varbinary type',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+// Migration file
+$table->addColumn('hash', 'binary', ['length' => 20, 'fixed' => true]);
+$table->addColumn('data', 'binary', ['length' => 255]);
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+// Migration file
+$table->addColumn('hash', 'binary', ['length' => 20]);
+$table->addColumn('data', 'varbinary', ['length' => 255]);
+CODE_SAMPLE,
+                ),
+            ],
+        );
+    }
+
+    /**
+     * @return array<class-string<\PhpParser\Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr\MethodCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (!$node->name instanceof Identifier) {
+            return null;
+        }
+
+        $methodName = $node->name->toString();
+
+        // Handle addColumn() calls in migrations
+        if ($methodName === 'addColumn') {
+            return $this->refactorAddColumn($node);
+        }
+
+        return null;
+    }
+
+    /**
+     * Refactor addColumn('name', 'binary', [...]) calls
+     */
+    private function refactorAddColumn(MethodCall $node): ?MethodCall
+    {
+        $args = $node->args;
+
+        // Need at least 2 arguments: column name and type
+        if (count($args) < 2) {
+            return null;
+        }
+
+        // Check if second argument is 'binary' type
+        $typeArg = $args[1];
+        if (!$typeArg instanceof Arg) {
+            return null;
+        }
+
+        if (!$typeArg->value instanceof String_) {
+            return null;
+        }
+
+        if ($typeArg->value->value !== 'binary') {
+            return null;
+        }
+
+        // Check third argument (options array) if it exists
+        $hasFixed = false;
+        $optionsArg = $args[2] ?? null;
+
+        if ($optionsArg instanceof Arg && $optionsArg->value instanceof Array_) {
+            $hasFixed = $this->hasFixedTrue($optionsArg->value);
+
+            if ($hasFixed) {
+                // Remove 'fixed' => true from the options
+                $this->removeFixedFromArray($optionsArg->value);
+            }
+        }
+
+        // If 'fixed' => true was set, keep as 'binary' (already correct after removing fixed)
+        // If 'fixed' was not set, change type to 'varbinary'
+        if (!$hasFixed) {
+            $typeArg->value = new String_('varbinary');
+        }
+
+        return $node;
+    }
+
+    /**
+     * Check if array contains 'fixed' => true
+     */
+    private function hasFixedTrue(Array_ $array): bool
+    {
+        foreach ($array->items as $item) {
+            if (!$item instanceof ArrayItem) {
+                continue;
+            }
+
+            if (
+                $item->key instanceof String_ &&
+                $item->key->value === 'fixed' &&
+                $this->valueResolver->isTrue($item->value)
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Remove 'fixed' key from array
+     */
+    private function removeFixedFromArray(Array_ $array): void
+    {
+        $array->items = array_values(array_filter(
+            $array->items,
+            function ($item) {
+                if (!$item instanceof ArrayItem) {
+                    return true;
+                }
+
+                return !($item->key instanceof String_ && $item->key->value === 'fixed');
+            },
+        ));
+    }
+}

--- a/src/Rector/Cake6/BinaryColumnToVarbinaryRector.php
+++ b/src/Rector/Cake6/BinaryColumnToVarbinaryRector.php
@@ -7,6 +7,7 @@ use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Scalar\String_;
@@ -135,7 +136,8 @@ CODE_SAMPLE,
             if (
                 $item->key instanceof String_ &&
                 $item->key->value === 'fixed' &&
-                $this->valueResolver->isTrue($item->value)
+                $item->value instanceof ConstFetch &&
+                strtolower($item->value->name->toString()) === 'true'
             ) {
                 return true;
             }

--- a/tests/TestCase/Rector/MethodCall/BinaryColumnToVarbinaryRector/BinaryColumnToVarbinaryRectorTest.php
+++ b/tests/TestCase/Rector/MethodCall/BinaryColumnToVarbinaryRector/BinaryColumnToVarbinaryRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Upgrade\Test\TestCase\Rector\MethodCall\BinaryColumnToVarbinaryRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class BinaryColumnToVarbinaryRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/TestCase/Rector/MethodCall/BinaryColumnToVarbinaryRector/Fixture/fixture.php.inc
+++ b/tests/TestCase/Rector/MethodCall/BinaryColumnToVarbinaryRector/Fixture/fixture.php.inc
@@ -1,0 +1,61 @@
+<?php
+
+namespace Cake\Upgrade\Test\TestCase\Rector\MethodCall\BinaryColumnToVarbinaryRector\Fixture;
+
+use Migrations\BaseMigration;
+
+class CreateTokensTable extends BaseMigration
+{
+    public function change(): void
+    {
+        $table = $this->table('tokens');
+
+        // Fixed-length binary - should remove 'fixed' => true
+        $table->addColumn('hash', 'binary', ['length' => 32, 'fixed' => true]);
+
+        // Variable-length binary - should change to 'varbinary'
+        $table->addColumn('data', 'binary', ['length' => 255]);
+
+        // Variable-length binary with other options - should change to 'varbinary'
+        $table->addColumn('payload', 'binary', ['length' => 1024, 'null' => true]);
+
+        // Non-binary types should not be affected
+        $table->addColumn('name', 'string', ['length' => 100]);
+        $table->addColumn('count', 'integer');
+
+        $table->create();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Cake\Upgrade\Test\TestCase\Rector\MethodCall\BinaryColumnToVarbinaryRector\Fixture;
+
+use Migrations\BaseMigration;
+
+class CreateTokensTable extends BaseMigration
+{
+    public function change(): void
+    {
+        $table = $this->table('tokens');
+
+        // Fixed-length binary - should remove 'fixed' => true
+        $table->addColumn('hash', 'binary', ['length' => 32]);
+
+        // Variable-length binary - should change to 'varbinary'
+        $table->addColumn('data', 'varbinary', ['length' => 255]);
+
+        // Variable-length binary with other options - should change to 'varbinary'
+        $table->addColumn('payload', 'varbinary', ['length' => 1024, 'null' => true]);
+
+        // Non-binary types should not be affected
+        $table->addColumn('name', 'string', ['length' => 100]);
+        $table->addColumn('count', 'integer');
+
+        $table->create();
+    }
+}
+
+?>

--- a/tests/TestCase/Rector/MethodCall/BinaryColumnToVarbinaryRector/config/configured_rule.php
+++ b/tests/TestCase/Rector/MethodCall/BinaryColumnToVarbinaryRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+use Cake\Upgrade\Rector\Cake6\BinaryColumnToVarbinaryRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(BinaryColumnToVarbinaryRector::class);
+};


### PR DESCRIPTION
## Summary

Adds a Rector rule to help users upgrade migration files for CakePHP 6.0 where `TYPE_VARBINARY` was added.

Related: https://github.com/cakephp/cakephp/pull/19258

## Transformations

**Fixed-length binary (with `fixed` attribute):**
```php
// Before
$table->addColumn('hash', 'binary', ['length' => 32, 'fixed' => true]);

// After
$table->addColumn('hash', 'binary', ['length' => 32]);
```

**Variable-length binary (without `fixed` attribute):**
```php
// Before
$table->addColumn('data', 'binary', ['length' => 255]);

// After
$table->addColumn('data', 'varbinary', ['length' => 255]);
```

## Notes

- This rule targets `addColumn()` calls in migration files
- The `fixed` attribute is removed since `binary` type is now always fixed-length
- Columns without `fixed => true` are converted to `varbinary` type