### PR TITLE
Add callable to Closure upgrade rules for CakePHP 6.0

### DIFF
--- a/config/rector/sets/cakephp60.php
+++ b/config/rector/sets/cakephp60.php
@@ -1059,4 +1059,61 @@ return static function (RectorConfig $rectorConfig): void {
     // 'binary' without 'fixed' becomes 'varbinary'
     // @see https://github.com/cakephp/cakephp/pull/19258
     $rectorConfig->rule(BinaryColumnToVarbinaryRector::class);
+
+    // ===== callable to Closure type changes =====
+    // These methods now use Closure instead of callable for more precise typing
+    // @see https://github.com/cakephp/cakephp/pull/19368
+    $rectorConfig->ruleWithConfiguration(AddParamTypeDeclarationRector::class, [
+        // CsrfProtectionMiddleware::skipCheckCallback()
+        new AddParamTypeDeclaration(
+            'Cake\Http\Middleware\CsrfProtectionMiddleware',
+            'skipCheckCallback',
+            0,
+            new ObjectType('Closure'),
+        ),
+        // SessionCsrfProtectionMiddleware::skipCheckCallback()
+        new AddParamTypeDeclaration(
+            'Cake\Http\Middleware\SessionCsrfProtectionMiddleware',
+            'skipCheckCallback',
+            0,
+            new ObjectType('Closure'),
+        ),
+        // View::cache()
+        new AddParamTypeDeclaration(
+            'Cake\View\View',
+            'cache',
+            0,
+            new ObjectType('Closure'),
+        ),
+        // TestCase::withErrorReporting()
+        new AddParamTypeDeclaration(
+            'Cake\TestSuite\TestCase',
+            'withErrorReporting',
+            1,
+            new ObjectType('Closure'),
+        ),
+        // Table::executeTransaction()
+        new AddParamTypeDeclaration(
+            'Cake\ORM\Table',
+            'executeTransaction',
+            0,
+            new ObjectType('Closure'),
+        ),
+        // AttributeCollection::filter()
+        new AddParamTypeDeclaration(
+            'Cake\AttributeResolver\AttributeCollection',
+            'filter',
+            0,
+            new ObjectType('Closure'),
+        ),
+    ]);
+
+    // ResultSetFactory::getDtoHydrator() return type
+    $rectorConfig->ruleWithConfiguration(AddReturnTypeDeclarationRector::class, [
+        new AddReturnTypeDeclaration(
+            'Cake\ORM\ResultSetFactory',
+            'getDtoHydrator',
+            new ObjectType('Closure'),
+        ),
+    ]);
 };


### PR DESCRIPTION
## Summary

Add Rector configuration to help users upgrade their code when overriding methods that changed from `callable` to `Closure` type hints in CakePHP 6.0.

### Parameter type changes:

| Class | Method | Parameter |
|-------|--------|-----------|
| `CsrfProtectionMiddleware` | `skipCheckCallback()` | `$callback` |
| `SessionCsrfProtectionMiddleware` | `skipCheckCallback()` | `$callback` |
| `View` | `cache()` | `$block` |
| `TestCase` | `withErrorReporting()` | `$callable` |
| `Table` | `executeTransaction()` | `$worker` |
| `AttributeCollection` | `filter()` | `$callback` |

### Return type changes:

| Class | Method |
|-------|--------|
| `ResultSetFactory` | `getDtoHydrator()` |

### Related

- Refs cakephp/cakephp#19368