### PR TITLE
Bump PHP requirement from 8.1 to 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage": "https://cakephp.org",
     "license": "MIT",
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "cakephp/console": "^5.0",
         "nette/utils": "^4.0",
         "rector/rector": "~2.4.0",


### PR DESCRIPTION
since github workflow is using php 8.2, I think the composer requirement should use php 8.2 as well.

https://github.com/cakephp/upgrade/blob/8d05fd9c64f8c3497970c98eb6668febf7bdfbe1/.github/workflows/ci.yml#L20