### PR TITLE
Update minimum PHP version badge to 8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CakePHP Upgrade tool
 
 [![CI](https://github.com/cakephp/upgrade/actions/workflows/ci.yml/badge.svg)](https://github.com/cakephp/upgrade/actions/workflows/ci.yml)
-[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%208.1-8892BF.svg)](https://php.net/)
+[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%208.2-8892BF.svg)](https://php.net/)
 [![License](https://poser.pugx.org/cakephp/upgrade/license.svg)](LICENSE)
 
 Upgrade tools for CakePHP meant to facilitate migrating between CakePHP 4.x


### PR DESCRIPTION
since minimum php version is now 8.2, the badge on readme can be updated to >=8.2 as well.

Ref PR:

- https://github.com/cakephp/upgrade/pull/397