### PR TITLE
fix possible rector internal timeout when processing large apps

### DIFF
--- a/config/rector/authentication40.php
+++ b/config/rector/authentication40.php
@@ -5,5 +5,6 @@ use Cake\Upgrade\Rector\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/defaults.php');
     $rectorConfig->sets([CakePHPSetList::AUTHENTICATION_40]);
 };

--- a/config/rector/cakephp40.php
+++ b/config/rector/cakephp40.php
@@ -5,5 +5,6 @@ use Cake\Upgrade\Rector\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/defaults.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_40]);
 };

--- a/config/rector/cakephp41.php
+++ b/config/rector/cakephp41.php
@@ -5,5 +5,6 @@ use Cake\Upgrade\Rector\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/default-rector.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_41]);
 };

--- a/config/rector/cakephp42.php
+++ b/config/rector/cakephp42.php
@@ -5,5 +5,6 @@ use Cake\Upgrade\Rector\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/defaults.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_42]);
 };

--- a/config/rector/cakephp43.php
+++ b/config/rector/cakephp43.php
@@ -5,5 +5,6 @@ use Cake\Upgrade\Rector\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/defaults.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_43]);
 };

--- a/config/rector/cakephp44.php
+++ b/config/rector/cakephp44.php
@@ -5,5 +5,6 @@ use Cake\Upgrade\Rector\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/defaults.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_44]);
 };

--- a/config/rector/cakephp45.php
+++ b/config/rector/cakephp45.php
@@ -5,5 +5,6 @@ use Cake\Upgrade\Rector\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/defaults.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_45]);
 };

--- a/config/rector/cakephp50.php
+++ b/config/rector/cakephp50.php
@@ -5,5 +5,6 @@ use Cake\Upgrade\Rector\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/defaults.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_50]);
 };

--- a/config/rector/cakephp51.php
+++ b/config/rector/cakephp51.php
@@ -5,5 +5,6 @@ use Cake\Upgrade\Rector\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/defaults.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_51]);
 };

--- a/config/rector/cakephp52.php
+++ b/config/rector/cakephp52.php
@@ -5,5 +5,6 @@ use Cake\Upgrade\Rector\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/defaults.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_52]);
 };

--- a/config/rector/cakephp53.php
+++ b/config/rector/cakephp53.php
@@ -5,5 +5,6 @@ use Cake\Upgrade\Rector\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/defaults.php');
     $rectorConfig->sets([CakePHPSetList::CAKEPHP_53]);
 };

--- a/config/rector/chronos3.php
+++ b/config/rector/chronos3.php
@@ -5,5 +5,6 @@ use Cake\Upgrade\Rector\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/defaults.php');
     $rectorConfig->sets([CakePHPSetList::CHRONOS_3]);
 };

--- a/config/rector/defaults.php
+++ b/config/rector/defaults.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+/**
+ * This file is/should be imported by all other rulesets to define
+ * default config overwrites which are needed for this app to work properly
+ */
+return static function (RectorConfig $rectorConfig): void {
+    // When processing very large apps rector's default 120 second timeout can be too low
+    $rectorConfig->parallel(600);
+};

--- a/config/rector/migrations45.php
+++ b/config/rector/migrations45.php
@@ -5,5 +5,6 @@ use Cake\Upgrade\Rector\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/defaults.php');
     $rectorConfig->sets([CakePHPSetList::MIGRATIONS_45]);
 };

--- a/config/rector/migrations50.php
+++ b/config/rector/migrations50.php
@@ -5,5 +5,6 @@ use Cake\Upgrade\Rector\Set\CakePHPSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/defaults.php');
     $rectorConfig->sets([CakePHPSetList::MIGRATIONS_50]);
 };

--- a/config/rector/phpunit80.php
+++ b/config/rector/phpunit80.php
@@ -5,5 +5,6 @@ use Rector\Config\RectorConfig;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 
 return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/defaults.php');
     $rectorConfig->sets([PHPUnitSetList::PHPUNIT_80]);
 };


### PR DESCRIPTION
While doing another check if the current 6.0 rector rules properly apply on the core I noticed, that rector times out internally.

This fixes this issue. Unfortunately there is no global rector config for this present which can be applied across all ruleset (at least as far as I and my AI agent know)

@samsonasik thoughts?

Specifically I am talking about this error:
```
[ERROR] Could not process                                                      
         "/Users/kevin/Documents/CakePHP/Org/upgrade/vendor/rector/rector/vendor
         /symplify/easy-parallel/src/ValueObject/ParallelProcess.php" file, due 
         to:                                                                    
         "Child process timed out after 120 seconds". On line: 96               

 [ERROR] Could not process some files, due to:                                  
         "Reached system errors count limit of 50, exiting...".                 

Something went wrong while running rector.
```

This happened to me while using the `6.x` of this branch and doing a
```
bin/cake upgrade rector --rules cakephp60 /Users/kevin/Documents/CakePHP/Org/cakephp/src
```
where `/Users/kevin/Documents/CakePHP/Org/cakephp` is on the current [`5.x` branch state.](https://github.com/cakephp/cakephp)

Therefore I tried to apply all rules from the CakePHP 6.0 ruleset to the whole core framework at once