### PR TITLE
Add cakephp54 rector ruleset

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ cd /path/to/upgrade
 
 # To apply upgrade rules from 5.2 to 5.3
 bin/cake upgrade rector --rules cakephp53 /path/to/your/app/src
+
+# To apply upgrade rules from 5.3 to 5.4
+bin/cake upgrade rector --rules cakephp54 /path/to/your/app/src
 ```
 
 There are rules included for:
@@ -98,6 +101,7 @@ There are rules included for:
 - cakephp51
 - cakephp52
 - cakephp53
+- cakephp54
 
 ## Additional Rulesets
 

--- a/config/rector/cakephp54.php
+++ b/config/rector/cakephp54.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+use Cake\Upgrade\Rector\Set\CakePHPSetList;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/defaults.php');
+    $rectorConfig->sets([CakePHPSetList::CAKEPHP_54]);
+};

--- a/config/rector/sets/cakephp54.php
+++ b/config/rector/sets/cakephp54.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+use Cake\Upgrade\Rector\Rector\MethodCall\DisableHydrationToUnhydratedFindRector;
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+
+# @see https://book.cakephp.org/5/en/appendices/5-4-migration-guide.html
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
+        'Cake\Command\Helper\BannerHelper' => 'Cake\Console\Helper\BannerHelper',
+        'Cake\Command\Helper\ProgressHelper' => 'Cake\Console\Helper\ProgressHelper',
+        'Cake\Command\Helper\TableHelper' => 'Cake\Console\Helper\TableHelper',
+        'Cake\Command\Helper\TreeHelper' => 'Cake\Console\Helper\TreeHelper',
+    ]);
+    $rectorConfig->rule(DisableHydrationToUnhydratedFindRector::class);
+};

--- a/src/Rector/Rector/MethodCall/DisableHydrationToUnhydratedFindRector.php
+++ b/src/Rector/Rector/MethodCall/DisableHydrationToUnhydratedFindRector.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Upgrade\Rector\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Type\ObjectType;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Transforms Table::find()->disableHydration() to Table::unhydratedFind().
+ *
+ * @see https://book.cakephp.org/5/en/appendices/5-4-migration-guide.html
+ */
+final class DisableHydrationToUnhydratedFindRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Change Table::find()->disableHydration() to Table::unhydratedFind()',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+$articles->find('all')->disableHydration();
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+$articles->unhydratedFind('all');
+CODE_SAMPLE,
+                ),
+            ],
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if (!$node instanceof MethodCall) {
+            return null;
+        }
+
+        if (!$node->name instanceof Identifier || $node->name->toString() !== 'disableHydration') {
+            return null;
+        }
+
+        if (count($node->args) !== 0) {
+            return null;
+        }
+
+        $current = $node->var;
+        while ($current instanceof MethodCall) {
+            if ($current->name instanceof Identifier && $current->name->toString() === 'find') {
+                if (!(new ObjectType('Cake\ORM\Table'))->isSuperTypeOf($this->getType($current->var))->yes()) {
+                    return null;
+                }
+
+                $current->name = new Identifier('unhydratedFind');
+
+                return $node->var;
+            }
+
+            $current = $current->var;
+        }
+
+        return null;
+    }
+}

--- a/src/Rector/Set/CakePHPSetList.php
+++ b/src/Rector/Set/CakePHPSetList.php
@@ -88,6 +88,11 @@ final class CakePHPSetList
     /**
      * @var string
      */
+    public const CAKEPHP_54 = __DIR__ . '/../../../config/rector/sets/cakephp54.php';
+
+    /**
+     * @var string
+     */
     public const CHRONOS_3 = __DIR__ . '/../../../config/rector/sets/chronos3.php';
 
     /**

--- a/tests/TestCase/Command/RectorCommandTest.php
+++ b/tests/TestCase/Command/RectorCommandTest.php
@@ -123,6 +123,13 @@ class RectorCommandTest extends TestCase
         $this->assertTestAppUpgraded();
     }
 
+    public function testApply54()
+    {
+        $this->setupTestApp(__FUNCTION__);
+        $this->exec('upgrade rector --rules cakephp54 ' . TEST_APP);
+        $this->assertTestAppUpgraded();
+    }
+
     public function testApplyMigrations45()
     {
         $this->setupTestApp(__FUNCTION__);

--- a/tests/TestCase/Rector/MethodCall/DisableHydrationToUnhydratedFindRector/DisableHydrationToUnhydratedFindRectorTest.php
+++ b/tests/TestCase/Rector/MethodCall/DisableHydrationToUnhydratedFindRector/DisableHydrationToUnhydratedFindRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Upgrade\Test\TestCase\Rector\MethodCall\DisableHydrationToUnhydratedFindRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class DisableHydrationToUnhydratedFindRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/TestCase/Rector/MethodCall/DisableHydrationToUnhydratedFindRector/Fixture/fixture.php.inc
+++ b/tests/TestCase/Rector/MethodCall/DisableHydrationToUnhydratedFindRector/Fixture/fixture.php.inc
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Upgrade\Test\TestCase\Rector\MethodCall\DisableHydrationToUnhydratedFindRector\Fixture;
+
+use Cake\ORM\Table;
+
+class MyRepository
+{
+    public function index(Table $articles)
+    {
+        $articles->find()->disableHydration();
+        $articles->find('all')->disableHydration();
+        $articles->find()->where(['id' => 1])->contain(['Users'])->disableHydration();
+        $articles->find()->disableHydration()->toArray();
+    }
+}
+
+?>
+-----
+<?php
+declare(strict_types=1);
+
+namespace Cake\Upgrade\Test\TestCase\Rector\MethodCall\DisableHydrationToUnhydratedFindRector\Fixture;
+
+use Cake\ORM\Table;
+
+class MyRepository
+{
+    public function index(Table $articles)
+    {
+        $articles->unhydratedFind();
+        $articles->unhydratedFind('all');
+        $articles->unhydratedFind()->where(['id' => 1])->contain(['Users']);
+        $articles->unhydratedFind()->toArray();
+    }
+}
+
+?>

--- a/tests/TestCase/Rector/MethodCall/DisableHydrationToUnhydratedFindRector/Fixture/skip_detached_query.php.inc
+++ b/tests/TestCase/Rector/MethodCall/DisableHydrationToUnhydratedFindRector/Fixture/skip_detached_query.php.inc
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Upgrade\Test\TestCase\Rector\MethodCall\DisableHydrationToUnhydratedFindRector\Fixture;
+
+use Cake\ORM\Query\SelectQuery;
+use Cake\ORM\Table;
+
+class DetachedQuery
+{
+    public function index(Table $articles, SelectQuery $query)
+    {
+        // The find() call is not part of this chain, so there is nothing to rename.
+        $query->disableHydration();
+
+        // Associations do not have an unhydratedFind() counterpart.
+        $articles->getAssociation('Users')->find()->disableHydration();
+    }
+}
+
+?>

--- a/tests/TestCase/Rector/MethodCall/DisableHydrationToUnhydratedFindRector/Fixture/skip_not_a_table.php.inc
+++ b/tests/TestCase/Rector/MethodCall/DisableHydrationToUnhydratedFindRector/Fixture/skip_not_a_table.php.inc
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Upgrade\Test\TestCase\Rector\MethodCall\DisableHydrationToUnhydratedFindRector\Fixture;
+
+class NotATable
+{
+    public function find()
+    {
+        return $this;
+    }
+
+    public function disableHydration()
+    {
+        return $this;
+    }
+}
+
+class MyRepository
+{
+    public function index(NotATable $repository)
+    {
+        $repository->find()->disableHydration();
+    }
+}
+
+?>

--- a/tests/TestCase/Rector/MethodCall/DisableHydrationToUnhydratedFindRector/config/configured_rule.php
+++ b/tests/TestCase/Rector/MethodCall/DisableHydrationToUnhydratedFindRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+use Cake\Upgrade\Rector\Rector\MethodCall\DisableHydrationToUnhydratedFindRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(DisableHydrationToUnhydratedFindRector::class);
+};

--- a/tests/test_apps/original/RectorCommand-testApply54/src/SomeTest.php
+++ b/tests/test_apps/original/RectorCommand-testApply54/src/SomeTest.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace MyPlugin;
+
+use Cake\Command\Helper\TableHelper;
+use Cake\ORM\Locator\LocatorAwareTrait;
+
+class SomeTest
+{
+    use LocatorAwareTrait;
+
+    private TableHelper $Table;
+
+    public function testRenames(): void
+    {
+        $table = $this->fetchTable('Articles');
+        $results = $table->find()->where(['published' => true])->disableHydration();
+    }
+}

--- a/tests/test_apps/upgraded/RectorCommand-testApply54/src/SomeTest.php
+++ b/tests/test_apps/upgraded/RectorCommand-testApply54/src/SomeTest.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace MyPlugin;
+
+use Cake\Command\Helper\TableHelper;
+use Cake\ORM\Locator\LocatorAwareTrait;
+
+class SomeTest
+{
+    use LocatorAwareTrait;
+
+    private \Cake\Console\Helper\TableHelper $Table;
+
+    public function testRenames(): void
+    {
+        $table = $this->fetchTable('Articles');
+        $results = $table->unhydratedFind()->where(['published' => true]);
+    }
+}


### PR DESCRIPTION
The [5.4 migration guide](https://book.cakephp.org/5/en/appendices/5-4-migration-guide.html) already tells users to run

```
bin/cake upgrade rector --rules cakephp54 <path/to/app/src>
```

but there was no such ruleset, so the command failed. This adds it.

### What is automated

Two of the 5.4 changes are mechanically automatable:

**Console helper namespace move.** `Cake\Command\Helper\{Banner,Progress,Table,Tree}Helper` are deprecated in favor of `Cake\Console\Helper\*`. The core keeps `class_alias` shims, so a plain `RenameClassRector` mapping is enough.

**`SelectQuery::disableHydration()` -> `Table::unhydratedFind()`.** New `DisableHydrationToUnhydratedFindRector` collapses the chain:

```php
// before
$articles->find('all')->disableHydration();
$articles->find()->where(['id' => 1])->contain(['Users'])->disableHydration();

// after
$articles->unhydratedFind('all');
$articles->unhydratedFind()->where(['id' => 1])->contain(['Users']);
```

It walks down the fluent chain to the originating `find()` call, so intermediate calls are preserved. It deliberately skips:

- receivers that are not a `Cake\ORM\Table` (associations have no `unhydratedFind()` counterpart)
- detached queries, i.e. `$query->disableHydration()` where the `find()` call is not part of the same chain

Those cases still need a manual look, since the replacement returns a different class (`UnhydratedSelectQuery`).

### Not automated (deliberately)

- `EventAwareApplicationInterface::pluginEvents()` is deprecated but still declared on the interface in 5.4, so removing the implementation would break the contract until 6.0. This belongs in the `cakephp60` set.
- Commands are now attached to the event manager by default, so existing manual attach calls should be dropped. Detecting those reliably is too pattern-dependent for a safe codemod.
- `Mailer::$name` is deprecated as unused; removing a property an app might still read is not safe to do blind.
- The `HasMany` / `BelongsToMany` default strategy change (`select` -> `subquery`) could be pinned back with an opt-in BC ruleset that injects `'strategy' => 'select'`. Happy to add that as a follow-up if wanted, but it is opinionated enough that it should not be in the default set.
- Everything else in the guide is runtime behavior (`BaseCommand::initialize()` ordering, subcommand token rejection, `Number::parseFloat()` returning null, deferred `afterSaveCommit`/`afterDeleteCommit`, cross-table entity assertions, the FormHelper `hidden` attribute) with no PHP-level rewrite.

### Notes

- `RectorCommandTest::testApply54` plus original/upgraded app fixtures cover the set end to end; the rule itself has focused fixtures including two skip cases.
- The upgraded fixture keeps the now-unused import and emits an FQCN in the property type. That is existing `RenameClassRector` behavior in this repo, matching the `cakephp53` fixture.
- `FileRenameCommandTest::testTemplates` errors locally on `5.x` as well, unrelated to this change.
