### PR TITLE
Fix stale console helper namespace in cakephp60 set

### DIFF
--- a/config/rector/sets/cakephp60.php
+++ b/config/rector/sets/cakephp60.php
@@ -60,6 +60,11 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
         'Cake\Database\DriverFeatureEnum' => 'Cake\Database\Enum\DriverFeature',
         'Cake\Http\Cookie\SameSiteEnum' => 'Cake\Http\Cookie\Enum\SameSite',
+        // Console helpers moved namespace in 5.4, the Cake\Command\Helper namespace is gone in 6.0
+        'Cake\Command\Helper\BannerHelper' => 'Cake\Console\Helper\BannerHelper',
+        'Cake\Command\Helper\ProgressHelper' => 'Cake\Console\Helper\ProgressHelper',
+        'Cake\Command\Helper\TableHelper' => 'Cake\Console\Helper\TableHelper',
+        'Cake\Command\Helper\TreeHelper' => 'Cake\Console\Helper\TreeHelper',
     ]);
 
     // Related method rename for SameSite enum
@@ -97,6 +102,7 @@ return static function (RectorConfig $rectorConfig): void {
             'Cake\Collection\Iterator\ZipIterator' => ['_callback', '_iterators'],
         ],
         'Command' => [
+            // Pre 5.4 location, kept for apps upgrading straight from 5.3 or older
             'Cake\Command\Helper\ProgressHelper' => ['_progress', '_total', '_width'],
             'Cake\Command\I18nExtractCommand' => [
                 '_paths', '_files', '_merge', '_file', '_storage', '_tokens', '_translations',
@@ -105,6 +111,7 @@ return static function (RectorConfig $rectorConfig): void {
             'Cake\Command\ServerCommand' => ['_host', '_port', '_documentRoot', '_iniPath'],
         ],
         'Console' => [
+            'Cake\Console\Helper\ProgressHelper' => ['_progress', '_total', '_width'],
             'Cake\Console\TestSuite\ConsoleIntegrationTestTrait' => ['_exitCode', '_out', '_err', '_in'],
             'Cake\Console\TestSuite\StubConsoleOutput' => ['_out'],
             'Cake\Console\ConsoleInput' => ['_input', '_canReadline'],
@@ -523,6 +530,7 @@ return static function (RectorConfig $rectorConfig): void {
             'Cake\Collection\Iterator\TreePrinter' => ['_fetchCurrent'],
         ],
         'Command' => [
+            // Pre 5.4 location, kept for apps upgrading straight from 5.3 or older
             'Cake\Command\Helper\TreeHelper' => [
                 '_calculateWidths', '_cellWidth', '_rowSeparator', '_render', '_addStyle',
             ],
@@ -541,6 +549,12 @@ return static function (RectorConfig $rectorConfig): void {
             ],
         ],
         'Console' => [
+            'Cake\Console\Helper\TreeHelper' => [
+                '_calculateWidths', '_cellWidth', '_rowSeparator', '_render', '_addStyle',
+            ],
+            'Cake\Console\Helper\TableHelper' => [
+                '_calculateWidths', '_cellWidth', '_rowSeparator', '_render', '_addStyle',
+            ],
             'Cake\Console\HelpFormatter' => ['_generateUsage', '_getMaxLength'],
             'Cake\Console\ConsoleIo' => ['_getInput'],
             'Cake\Console\ConsoleOutput' => ['_replaceTags'],

--- a/tests/test_apps/original/RectorCommand-testApply60/src/ConsoleHelperExample.php
+++ b/tests/test_apps/original/RectorCommand-testApply60/src/ConsoleHelperExample.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace MyPlugin;
+
+use Cake\Command\Helper\TableHelper;
+
+class ConsoleHelperExample
+{
+    private TableHelper $Table;
+
+    public function render(): void
+    {
+        $this->Table->output([['a', 'b']]);
+    }
+}

--- a/tests/test_apps/upgraded/RectorCommand-testApply60/src/ConsoleHelperExample.php
+++ b/tests/test_apps/upgraded/RectorCommand-testApply60/src/ConsoleHelperExample.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace MyPlugin;
+
+use Cake\Command\Helper\TableHelper;
+
+class ConsoleHelperExample
+{
+    private \Cake\Console\Helper\TableHelper $Table;
+
+    public function render(): void
+    {
+        $this->Table->output([['a', 'b']]);
+    }
+}


### PR DESCRIPTION
Follow-up to #408.

Console helpers moved from `Cake\Command\Helper` to `Cake\Console\Helper` in 5.4 (core keeps `class_alias` shims there), and the old namespace is removed entirely in 6.0. The `cakephp60` set did not account for that:

- There was no class rename, so an app coming from 5.3 or older kept referencing a namespace that no longer exists in 6.0.
- The underscore property and method maps were keyed only on `Cake\Command\Helper\{Progress,Table,Tree}Helper`. For anyone who had already run `cakephp54` (or moved by hand), those entries never matched, so `_progress`, `_calculateWidths`, `_render` and friends were silently left alone.

This adds the rename and registers the maps under `Cake\Console\Helper\*` as well. The old keys stay in place, since an app upgrading straight from 5.3 still resolves those classes to their pre 5.4 location and would otherwise miss the underscore renames.

Covered by a new `ConsoleHelperExample` fixture in the `testApply60` app.

Note: the upgraded fixture keeps the now-unused `use Cake\Command\Helper\TableHelper;` and emits an FQCN in the property type. That is how `RenameClassRector` behaves throughout this repo (the `cakephp53` fixture shows the same), and an unused import of a removed class is inert at runtime. Worth cleaning up globally at some point, but that would churn every set's fixtures, so it is out of scope here.
